### PR TITLE
Relocate and update survey plugins

### DIFF
--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -9,8 +9,78 @@ from aiogram import Dispatcher, types
 from aiogram.dispatcher import FSMContext
 from aiogram.dispatcher.filters.state import State, StatesGroup
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-from database import get_survey_by_id, get_question_by_id, update_question, get_surveys
-from utils import is_admin
+
+# Replace deprecated database imports with db_manager helpers
+from core.db_manager import (
+    DATABASE,
+    get_all_polls,
+    get_poll_id_by_name,
+    get_poll_by_id,
+    get_questions_by_poll,
+)
+import sqlite3
+import os
+from dotenv import load_dotenv
+from typing import List, Dict, Optional
+
+load_dotenv()
+ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x]
+
+
+def is_admin(user_id: int) -> bool:
+    """Check if a user is an administrator."""
+    return user_id in ADMIN_IDS
+
+
+async def get_surveys(creator_id: Optional[int] = None) -> List[Dict]:
+    """Return a list of all surveys."""
+    surveys = []
+    for name in get_all_polls():
+        poll_id = get_poll_id_by_name(name)
+        poll = get_poll_by_id(poll_id)
+        if not poll:
+            continue
+        poll_data = {
+            "id": poll_id,
+            "title": poll["name"],
+            "questions": get_questions_by_poll(poll_id),
+            "time_limit": poll.get("time_limit"),
+        }
+        surveys.append(poll_data)
+    return surveys
+
+
+async def get_survey_by_id(survey_id: int) -> Optional[Dict]:
+    """Fetch a survey by its ID."""
+    poll = get_poll_by_id(survey_id)
+    if not poll:
+        return None
+    poll["title"] = poll.pop("name")
+    poll["questions"] = get_questions_by_poll(survey_id)
+    return poll
+
+
+async def update_question(survey_id: int, question_index: int, question: Dict) -> bool:
+    """Update a question in the database."""
+    conn = sqlite3.connect(DATABASE)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id FROM questions WHERE poll_id = ? ORDER BY id LIMIT 1 OFFSET ?",
+        (survey_id, question_index),
+    )
+    row = cursor.fetchone()
+    if not row:
+        conn.close()
+        return False
+    question_id = row[0]
+    options_str = ",".join(question.get("options", [])) if question.get("options") else None
+    cursor.execute(
+        "UPDATE questions SET text = ?, type = ?, options = ? WHERE id = ?",
+        (question.get("text"), question.get("type"), options_str, question_id),
+    )
+    conn.commit()
+    conn.close()
+    return True
 
 
 class EditQuestionStates(StatesGroup):

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -9,8 +9,64 @@ from aiogram import Dispatcher, types
 from aiogram.dispatcher import FSMContext
 from aiogram.dispatcher.filters.state import State, StatesGroup
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-from database import get_surveys, get_survey_by_id
-from utils import format_survey_info, has_poll_ended
+
+# Use helpers from db_manager instead of the missing database module
+from core.db_manager import (
+    get_all_polls,
+    get_poll_id_by_name,
+    get_poll_by_id,
+    get_questions_by_poll,
+)
+from datetime import datetime
+from typing import List, Dict, Optional
+
+
+async def get_surveys(user_id: Optional[int] = None) -> List[Dict]:
+    """Return all available surveys."""
+    surveys = []
+    for name in get_all_polls():
+        poll_id = get_poll_id_by_name(name)
+        poll = get_poll_by_id(poll_id)
+        if not poll:
+            continue
+        surveys.append({
+            "id": poll_id,
+            "title": poll["name"],
+            "questions": get_questions_by_poll(poll_id),
+            "time_limit": poll.get("time_limit"),
+        })
+    return surveys
+
+
+async def get_survey_by_id(survey_id: int) -> Optional[Dict]:
+    """Fetch a survey by ID."""
+    poll = get_poll_by_id(survey_id)
+    if not poll:
+        return None
+    poll["title"] = poll.pop("name")
+    poll["questions"] = get_questions_by_poll(survey_id)
+    return poll
+
+
+async def format_survey_info(survey: Dict) -> str:
+    """Format survey details for display."""
+    info = f"<b>{survey.get('title')}</b>\n"
+    info += f"Questions: {len(survey.get('questions', []))}\n"
+    if survey.get("time_limit"):
+        info += f"Ends: {survey['time_limit']}\n"
+    return info
+
+
+def has_poll_ended(survey: Dict) -> bool:
+    """Return True if the survey time limit has passed."""
+    tl = survey.get("time_limit")
+    if not tl:
+        return False
+    try:
+        end_time = datetime.fromisoformat(tl)
+    except (TypeError, ValueError):
+        return False
+    return datetime.now() > end_time
 
 
 class ViewSurveysStates(StatesGroup):


### PR DESCRIPTION
## Summary
- move `edit_question_plugin.py` and `view_surveys_plugin.py` into the `plugins` folder
- replace missing `database` helpers with functions from `core.db_manager`
- provide local helpers for admin checks and survey formatting
- keep `load_plugin()` entrypoints intact

## Testing
- `python -m py_compile plugins/edit_question_plugin.py plugins/view_surveys_plugin.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6864d1ff0a4c832aa3f7db3851091192