### PR TITLE
Update plugin imports and handlers for aiogram v3

### DIFF
--- a/plugin_template.py
+++ b/plugin_template.py
@@ -21,8 +21,9 @@ Optional methods:
 """
 
 from aiogram import Dispatcher, types
-from aiogram.dispatcher import FSMContext
-from aiogram.dispatcher.filters.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.filters import Command
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton, InlineKeyboardMarkup, InlineKeyboardButton
 
 
@@ -40,7 +41,7 @@ class PluginTemplate:
         
     async def register_handlers(self, dp: Dispatcher):
         """Register all handlers for this plugin"""
-        dp.register_message_handler(self.command_handler, commands=["template_command"])
+        dp.message.register(self.command_handler, Command("template_command"))
         # Register more handlers as needed
         
     def get_commands(self):

--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -6,8 +6,9 @@ It allows administrators to modify question text, options, and other properties.
 """
 
 from aiogram import Dispatcher, types
-from aiogram.dispatcher import FSMContext
-from aiogram.dispatcher.filters.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.filters import Command
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 # Replace deprecated database imports with db_manager helpers
@@ -103,25 +104,25 @@ class EditQuestionPlugin:
         
     async def register_handlers(self, dp: Dispatcher):
         """Register all handlers for this plugin"""
-        dp.register_message_handler(
-            self.cmd_edit_question, 
-            lambda msg: is_admin(msg.from_user.id),
-            commands=["edit_question"]
+        dp.message.register(
+            self.cmd_edit_question,
+            Command("edit_question"),
+            lambda msg: is_admin(msg.from_user.id)
         )
         
-        dp.register_callback_query_handler(
+        dp.callback_query.register(
             self.handle_survey_selection,
             lambda c: c.data.startswith('edit_survey_'),
             state=EditQuestionStates.SelectSurvey
         )
         
-        dp.register_callback_query_handler(
+        dp.callback_query.register(
             self.handle_question_selection,
             lambda c: c.data.startswith('edit_question_'),
             state=EditQuestionStates.SelectQuestion
         )
         
-        dp.register_callback_query_handler(
+        dp.callback_query.register(
             self.handle_edit_action,
             lambda c: c.data.startswith('edit_action_'),
             state=[
@@ -132,17 +133,17 @@ class EditQuestionPlugin:
             ]
         )
         
-        dp.register_message_handler(
+        dp.message.register(
             self.process_question_text,
             state=EditQuestionStates.EditQuestionText
         )
         
-        dp.register_message_handler(
+        dp.message.register(
             self.process_new_option,
             state=EditQuestionStates.AddOption
         )
         
-        dp.register_callback_query_handler(
+        dp.callback_query.register(
             self.handle_remove_option,
             lambda c: c.data.startswith('remove_option_'),
             state=EditQuestionStates.RemoveOption

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -6,8 +6,9 @@ It allows users to list, filter, and view details of surveys.
 """
 
 from aiogram import Dispatcher, types
-from aiogram.dispatcher import FSMContext
-from aiogram.dispatcher.filters.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.filters import Command
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 # Use helpers from db_manager instead of the missing database module
@@ -85,18 +86,18 @@ class ViewSurveysPlugin:
         
     async def register_handlers(self, dp: Dispatcher):
         """Register all handlers for this plugin"""
-        dp.register_message_handler(self.cmd_view_surveys, commands=["view_surveys"])
-        dp.register_callback_query_handler(
-            self.handle_survey_selection, 
+        dp.message.register(self.cmd_view_surveys, Command("view_surveys"))
+        dp.callback_query.register(
+            self.handle_survey_selection,
             lambda c: c.data.startswith('view_survey_'),
             state=ViewSurveysStates.Viewing
         )
-        dp.register_callback_query_handler(
+        dp.callback_query.register(
             self.handle_filter_selection,
             lambda c: c.data.startswith('filter_'),
             state=ViewSurveysStates.FilterMenu
         )
-        dp.register_callback_query_handler(
+        dp.callback_query.register(
             self.handle_survey_action,
             lambda c: c.data.startswith('survey_action_'),
             state=ViewSurveysStates.ViewingDetails


### PR DESCRIPTION
## Summary
- use `aiogram.fsm.context` and `aiogram.fsm.state` in plugin template
- update Edit Question plugin to aiogram v3 imports and handler registration
- update View Surveys plugin to aiogram v3 imports and handler registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864e98ebff0832aa5724483c50e85c2