### PR TITLE
Add plugin creation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Creating a plugin
+
+1. Copy `plugin_template.py` from the project root into the `plugins` directory.
+   Name the new file using the pattern `<your_name>_plugin.py`.
+2. Open the new file and implement the methods described in the template:
+   - `register_handlers`
+   - `get_commands`
+   - Optional hooks such as `get_keyboards`, `on_plugin_load` and `on_plugin_unload`
+3. Make sure the file exposes a `load_plugin()` function that returns an instance
+   of your plugin class. The plugin manager relies on this function to load the
+   plugin.
+
+Files that follow the `*_plugin.py` naming convention are loaded automatically
+when the bot starts. If you remove or rename the file so it no longer matches
+this pattern, the plugin is disabled. You can also disable or enable a plugin at
+runtime using `PluginManager.unload_plugin()` and `PluginManager.load_plugin()`
+respectively.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Use the correct Python executable if you have multiple versions installed (e.g. 
 
 Plugins live in the `plugins` directory. `plugin_manager.py` automatically loads every file that ends with `_plugin.py`.
 
+For a walkthrough on creating your own plugin using `plugin_template.py` see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 Example usage:
 
 ```python


### PR DESCRIPTION
## Summary
- document how to create a plugin in CONTRIBUTING.md
- mention the new guide in the README

## Testing
- `python -m py_compile plugin_manager.py plugin_template.py`

------
https://chatgpt.com/codex/tasks/task_e_686501a68f3c832ab2210025f1be1437