### PR TITLE
Add plugin compilation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ After configuring `.env` run:
 python main.py
 ```
 
+## Running tests
+
+Run the test suite with:
+
+```bash
+pytest
+```
+
 Use the correct Python executable if you have multiple versions installed (e.g. `python3.10 main.py`).
 
 ## Plugins
@@ -79,3 +87,11 @@ Load it again with `load_plugin('test_mode_plugin')`.
 python main.py
 ```
 
+
+## Running tests
+
+Run the test suite with:
+
+```bash
+pytest
+```

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,16 @@
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1] / 'plugins'
+
+plugin_files = [p for p in PLUGIN_DIR.glob('*_plugin.py') if p.is_file()]
+
+@pytest.mark.parametrize('plugin_file', plugin_files, ids=[p.stem for p in plugin_files])
+def test_import_and_compile(plugin_file):
+    module_name = f"plugins.{plugin_file.stem}"
+    importlib.import_module(module_name)
+    subprocess.run([sys.executable, '-m', 'py_compile', str(plugin_file)], check=True)
+


### PR DESCRIPTION
## Summary
- add a pytest suite that imports each plugin and compiles it
- document running the test suite

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650c342900832aa6b23744902ec572