### PR TITLE
Fix BotCommand usage in plugins

### DIFF
--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -152,7 +152,10 @@ class EditQuestionPlugin:
     def get_commands(self):
         """Return a list of commands this plugin provides"""
         return [
-            {"command": "edit_question", "description": "Edit questions in existing surveys"}
+            types.BotCommand(
+                command="edit_question",
+                description="Edit questions in existing surveys",
+            )
         ]
         
     def get_keyboards(self):

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -106,7 +106,10 @@ class ViewSurveysPlugin:
     def get_commands(self):
         """Return a list of commands this plugin provides"""
         return [
-            {"command": "view_surveys", "description": "View available surveys"}
+            types.BotCommand(
+                command="view_surveys",
+                description="View available surveys",
+            )
         ]
         
     def get_keyboards(self):


### PR DESCRIPTION
## Summary
- use aiogram.types.BotCommand for commands in edit and view plugins

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865301bacf8832a89dde9f5e155e815