### PR TITLE
Improve ADMIN_IDS parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cp example.env .env
 | --- | --- |
 | `BOT_TOKEN` | Токен, полученный от BotFather |
 | `DATABASE` | Путь к файлу базы SQLite |
-| `ADMIN_IDS` | ID администраторов Telegram через запятую |
+| `ADMIN_IDS` | ID администраторов Telegram через запятую. Допустимы формы `123,456` и `[123,456]` |
 | `ENABLE_LOGGING` | Включить дополнительное логирование (`True` или `False`) |
 | `LOGGING_LEVEL` | Уровень логирования (например, `DEBUG` или `INFO`) |
 | `ENABLE_CAPTCHA` | Использовать капчу для новых участников групп |

--- a/plugins/admin_plugin.py
+++ b/plugins/admin_plugin.py
@@ -8,10 +8,12 @@ import logging
 from aiogram.client.bot import Bot
 from core.db_manager import get_all_groups, get_poll_by_id
 import os
+import re
 from dotenv import load_dotenv
 
 load_dotenv()
-ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x]
+ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
+ADMIN_IDS = [int(x) for x in ids]
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -21,11 +21,13 @@ from core.db_manager import (
 )
 import sqlite3
 import os
+import re
 from dotenv import load_dotenv
 from typing import List, Dict, Optional
 
 load_dotenv()
-ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x]
+ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
+ADMIN_IDS = [int(x) for x in ids]
 
 
 def is_admin(user_id: int) -> bool:

--- a/tests/test_admin_ids_parsing.py
+++ b/tests/test_admin_ids_parsing.py
@@ -1,0 +1,11 @@
+import importlib
+import pytest
+
+@pytest.mark.parametrize("value", ["123,456", "[123,456]"])
+def test_admin_ids_parsing(value, monkeypatch):
+    monkeypatch.setenv("ADMIN_IDS", value)
+    admin_module = importlib.reload(importlib.import_module("plugins.admin_plugin"))
+    edit_module = importlib.reload(importlib.import_module("plugins.edit_question_plugin"))
+    assert admin_module.ADMIN_IDS == [123, 456]
+    assert edit_module.ADMIN_IDS == [123, 456]
+


### PR DESCRIPTION
## Summary
- allow brackets in ADMIN_IDS parsing for admin and edit question plugins
- document ADMIN_IDS formats
- test ADMIN_IDS parsing for bracketed values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686597fc6a6c832a8e0343d913d558fa