### PR TITLE
Replace state.finish with state.clear in plugins

### DIFF
--- a/plugins/roles_plugin.py
+++ b/plugins/roles_plugin.py
@@ -322,7 +322,7 @@ class RolesPlugin:
         
         if not user_id:
             await callback_query.answer("Ошибка: пользователь не выбран")
-            await state.finish()
+            await state.clear()
             return
         
         # Назначаем роль
@@ -336,7 +336,7 @@ class RolesPlugin:
             f"✅ Роль {role_name} успешно назначена пользователю {user_id}."
         )
         
-        await state.finish()
+        await state.clear()
         await callback_query.answer()
     
     async def process_role_name(self, message: types.Message, state: FSMContext):
@@ -481,7 +481,7 @@ class RolesPlugin:
             "✅ Разрешения роли успешно сохранены."
         )
         
-        await state.finish()
+        await state.clear()
         await callback_query.answer()
     
     def on_plugin_load(self):

--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -302,7 +302,7 @@ class SurveyPlugin:
 
             storage.save_survey(survey_id, survey)
             self._schedule_survey_notifications(survey)
-            await state.finish()
+            await state.clear()
             await message.answer(f"✅ Опрос '{data['title']}' успешно создан!")
         else:
             await message.answer("Для подтверждения создания опроса введите 'Подтвердить':")
@@ -385,7 +385,7 @@ class SurveyPlugin:
     async def process_edit_question(self, callback_query: types.CallbackQuery, state: FSMContext):
         """Обрабатывает выбор вопроса для редактирования"""
         if callback_query.data == "edit_cancel":
-            await state.finish()
+            await state.clear()
             await callback_query.message.answer("Редактирование отменено")
             return
 
@@ -417,7 +417,7 @@ class SurveyPlugin:
         survey = storage.get_survey(survey_id)
         if not survey:
             await message.answer("Опрос не найден")
-            await state.finish()
+            await state.clear()
             return
 
         for question in survey['questions']:
@@ -427,7 +427,7 @@ class SurveyPlugin:
 
         storage.save_survey(survey_id, survey)
         await message.answer("✅ Вопрос успешно обновлен!")
-        await state.finish()
+        await state.clear()
 
     def _generate_survey_summary(self, data):
         """Генерирует сводку опроса для подтверждения"""

--- a/plugins/test_mode_plugin.py
+++ b/plugins/test_mode_plugin.py
@@ -67,7 +67,7 @@ class TestModePlugin:
         survey = storage.get_survey(survey_id)
         if not survey:
             await callback_query.answer("Опрос не найден.")
-            await state.finish()
+            await state.clear()
             return
         # Создаём копию опроса для тестирования
         test_survey = copy.deepcopy(survey)
@@ -93,14 +93,14 @@ class TestModePlugin:
         action = parts[2]
         if action == "exit":
             await callback_query.message.edit_text("Тестовый режим завершен.")
-            await state.finish()
+            await state.clear()
             await callback_query.answer()
             return
         test_id = parts[3]
         test_survey = self.test_surveys.get(test_id)
         if not test_survey:
             await callback_query.answer("Тестовый опрос не найден.")
-            await state.finish()
+            await state.clear()
             return
         if action == "start":
             await self.start_test_survey(callback_query, test_survey, test_id)
@@ -175,7 +175,7 @@ class TestModePlugin:
         test_survey = self.test_surveys.get(test_id)
         if not test_survey:
             await callback_query.answer("Тестовый опрос не найден.")
-            await state.finish()
+            await state.clear()
             return
         questions = test_survey.get("questions", [])
         if question_index >= len(questions):

--- a/plugins/text_answer_plugin.py
+++ b/plugins/text_answer_plugin.py
@@ -113,13 +113,13 @@ class TextAnswerPlugin:
         
         if not survey_id or not question_id:
             await message.reply("Произошла ошибка. Пожалуйста, начните заново.")
-            await state.finish()
+            await state.clear()
             return
         
         survey = storage.get_survey(survey_id)
         if not survey or survey['status'] != 'active':
             await message.reply("Этот опрос больше не доступен.")
-            await state.finish()
+            await state.clear()
             return
         
         user_id = message.from_user.id
@@ -137,7 +137,7 @@ class TextAnswerPlugin:
         storage.save_survey(survey_id, survey)
         
         await message.reply("✅ Ваш ответ записан! Спасибо за участие.")
-        await state.finish()
+        await state.clear()
     
     def _add_or_update_response(self, survey, user_id, question_id, new_response):
         """Добавляет или обновляет ответ в опросе"""

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -266,7 +266,7 @@ class ViewSurveysPlugin:
             # Обычно здесь происходит переход к другому плагину
             await callback_query.message.answer(f"Запускаем опрос {survey_id}...")
             # Сбрасываем состояние, чтобы другие хендлеры могли продолжить
-            await state.finish()
+            await state.clear()
             
         await callback_query.answer()
 


### PR DESCRIPTION
## Summary
- switch `await state.finish()` calls to `await state.clear()` in plugins
- ensure repository still passes tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686621ad4ccc832a9831131b8caea259