### PR TITLE
Fix option processing in survey plugin

### DIFF
--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -207,10 +207,10 @@ class SurveyPlugin:
             await message.answer("Введите срок действия опроса в часах (например, 24):")
         else:
             options = message.text.split('\n')
-            async with state.proxy() as data:
-                if 'options' not in data:
-                    data['options'] = []
-                data['options'].extend(options)
+            data = await state.get_data()
+            updated_options = data.get('options', [])
+            updated_options.extend(options)
+            await state.update_data(options=updated_options)
             await message.answer(f"Добавлено {len(options)} вариантов. Продолжайте добавлять или введите 'Готово':")
 
     async def process_deadline(self, message: types.Message, state: FSMContext):


### PR DESCRIPTION
## Summary
- simplify options handling in `process_options`
- update options via `state.update_data`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665f177514832ab8c0646498d40aaf