### PR TITLE
Implement scheduling of surveys

### DIFF
--- a/plugins/scheduler_plugin.py
+++ b/plugins/scheduler_plugin.py
@@ -28,6 +28,7 @@ except ImportError:
     storage = DummyStorage()
 
 logger = logging.getLogger(__name__)
+scheduler_instance = None
 
 class SchedulerStates(StatesGroup):
     """Состояния (States) для функционала планирования"""
@@ -44,6 +45,7 @@ class SchedulerPlugin:
         self.description = "Scheduling functionality for surveys"
         self.scheduled_tasks = {}
         self.reminder_tasks = {}
+        self.close_tasks = {}
 
     async def register_handlers(self, dp: Dispatcher):
         """
@@ -299,12 +301,19 @@ class SchedulerPlugin:
         task = asyncio.create_task(self._send_scheduled_survey(survey_id, time_delta))
         self.scheduled_tasks[survey_id] = task
 
-        # Напоминание за 10 минут до (если есть хотя бы 10 минут)
-        if time_delta > 600:
-            reminder_task = asyncio.create_task(
-                self._send_reminder(survey_id, time_delta - 600)
-            )
-            self.reminder_tasks[survey_id] = reminder_task
+        survey = storage.get_survey(survey_id)
+        if survey:
+            try:
+                deadline = datetime.datetime.fromisoformat(survey.get('deadline'))
+                reminder_time = deadline - datetime.timedelta(minutes=10)
+                reminder_delta = (reminder_time - now).total_seconds()
+                if reminder_delta > 0:
+                    reminder_task = asyncio.create_task(
+                        self._send_reminder(survey_id, reminder_delta)
+                    )
+                    self.reminder_tasks[survey_id] = reminder_task
+            except Exception as e:
+                logger.error(f"Failed to schedule reminder for {survey_id}: {e}")
 
     async def _send_scheduled_survey(self, survey_id, delay_seconds):
         """Ждём delay_seconds, затем отправляем опрос"""
@@ -351,6 +360,18 @@ class SchedulerPlugin:
             scheduled_surveys = [s for s in scheduled_surveys if s.get('survey_id') != survey_id]
             storage.set_setting('scheduled_surveys', scheduled_surveys)
 
+            # Планируем закрытие опроса
+            try:
+                deadline = datetime.datetime.fromisoformat(survey.get('deadline'))
+                close_delta = (deadline - datetime.datetime.now()).total_seconds()
+                if close_delta > 0:
+                    close_task = asyncio.create_task(
+                        self._close_survey(survey_id, close_delta)
+                    )
+                    self.close_tasks[survey_id] = close_task
+            except Exception as e:
+                logger.error(f"Failed to schedule close task for {survey_id}: {e}")
+
             logger.info(f"Successfully sent scheduled survey {survey_id}")
 
         except asyncio.CancelledError:
@@ -359,7 +380,7 @@ class SchedulerPlugin:
             logger.error(f"Error in scheduled task for survey {survey_id}: {e}")
 
     async def _send_reminder(self, survey_id, delay_seconds):
-        """Отправляем напоминание за 10 минут до отправки опроса"""
+        """Отправляем напоминание за 10 минут до окончания опроса"""
         try:
             await asyncio.sleep(delay_seconds)
             survey = storage.get_survey(survey_id)
@@ -384,6 +405,21 @@ class SchedulerPlugin:
             logger.info(f"Reminder task for survey {survey_id} was cancelled")
         except Exception as e:
             logger.error(f"Error in reminder task for survey {survey_id}: {e}")
+
+    async def _close_survey(self, survey_id, delay_seconds):
+        """Закрывает опрос по истечении срока"""
+        try:
+            await asyncio.sleep(delay_seconds)
+            survey = storage.get_survey(survey_id)
+            if not survey or survey.get('status') != 'active':
+                return
+            survey['status'] = 'closed'
+            storage.save_survey(survey_id, survey)
+            logger.info(f"Survey {survey_id} closed due to deadline")
+        except asyncio.CancelledError:
+            logger.info(f"Close task for survey {survey_id} was cancelled")
+        except Exception as e:
+            logger.error(f"Error closing survey {survey_id}: {e}")
 
     async def cmd_list_scheduled(self, message: types.Message):
         """Обработка команды /scheduled — список запланированных опросов для данного пользователя"""
@@ -470,10 +506,14 @@ class SchedulerPlugin:
             task.cancel()
         for task in self.reminder_tasks.values():
             task.cancel()
+        for task in self.close_tasks.values():
+            task.cancel()
 
         logger.info("Scheduler plugin unloaded")
 
 
 def load_plugin():
     """Функция для загрузки плагина (aiogram-style)"""
-    return SchedulerPlugin()
+    global scheduler_instance
+    scheduler_instance = SchedulerPlugin()
+    return scheduler_instance

--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -10,7 +10,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command, StateFilter
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 import asyncio
 
 # Импортируем модуль хранилища
@@ -40,6 +40,8 @@ class SurveyStates(StatesGroup):
     QUESTION_TEXT = State()
     ADDING_OPTIONS = State()
     SCHEDULING = State()
+    SCHEDULE_DATE = State()
+    SCHEDULE_TIME = State()
     DEADLINE = State()
     ANONYMITY = State()
     CONFIRMATION = State()
@@ -181,6 +183,51 @@ class SurveyPlugin:
 
         await callback_query.answer()
 
+    async def process_schedule_date(self, message: types.Message, state: FSMContext):
+        """Обрабатывает ввод даты от пользователя"""
+        date_str = message.text.strip()
+        try:
+            day, month, year = map(int, date_str.split('.'))
+            selected_date = datetime(year, month, day)
+            if selected_date.date() < datetime.now().date():
+                await message.answer("Дата должна быть в будущем. Введите ещё раз:")
+                return
+            await state.update_data(scheduled_date=selected_date.isoformat())
+            await state.set_state(SurveyStates.SCHEDULE_TIME)
+            await message.answer("Введите время отправки в формате ЧЧ:ММ:")
+        except Exception:
+            await message.answer("Неверный формат даты. Используйте ДД.ММ.ГГГГ:")
+
+    async def process_schedule_time(self, message: types.Message, state: FSMContext):
+        """Обрабатывает ввод времени от пользователя"""
+        time_str = message.text.strip()
+        try:
+            hour, minute = map(int, time_str.split(':'))
+            if not (0 <= hour < 24 and 0 <= minute < 60):
+                await message.answer("Часы 0-23, минуты 0-59. Повторите ввод:")
+                return
+            data = await state.get_data()
+            date_iso = data.get('scheduled_date')
+            if not date_iso:
+                await message.answer("Произошла ошибка. Попробуйте заново.")
+                await state.clear()
+                return
+            base_date = datetime.fromisoformat(date_iso)
+            send_datetime = datetime.combine(base_date.date(), time(hour, minute))
+            if send_datetime <= datetime.now():
+                await message.answer("Укажите время в будущем.")
+                return
+            await state.update_data(scheduled_datetime=send_datetime.isoformat())
+            await state.set_state(SurveyStates.CONFIRMATION)
+
+            data.update({'scheduled_datetime': send_datetime.isoformat()})
+            summary = self._generate_survey_summary(data)
+            await message.answer(
+                f"{summary}\n\nДля подтверждения создания опроса введите 'Подтвердить':"
+            )
+        except Exception:
+            await message.answer("Неверный формат времени. Используйте ЧЧ:ММ:")
+
     async def process_question_text(self, message: types.Message, state: FSMContext):
         """Обрабатывает ввод текста вопроса"""
         await state.update_data(question_text=message.text)
@@ -271,9 +318,10 @@ class SurveyPlugin:
             )
         else:
             await callback_query.message.edit_text(
-                "Функция планирования будет доступна в ближайшее время.\n\nОпрос будет создан для немедленной отправки.\nДля подтверждения введите 'Подтвердить':"
+                "Введите дату отправки в формате ДД.ММ.ГГГГ:",
             )
-            await state.set_state(SurveyStates.CONFIRMATION)
+            await state.update_data(scheduled=True)
+            await state.set_state(SurveyStates.SCHEDULE_DATE)
 
         await callback_query.answer()
 
@@ -296,12 +344,38 @@ class SurveyPlugin:
                     'type': data['question_type'],
                     'options': data.get('options', []) if data['question_type'] != "текстовый ответ" else []
                 }],
-                'responses': [],
-                'status': 'active'
+                'responses': []
             }
 
+            if data.get('scheduled'):
+                survey['status'] = 'scheduled'
+                survey['scheduled_time'] = data.get('scheduled_datetime')
+            else:
+                survey['status'] = 'active'
+
             storage.save_survey(survey_id, survey)
-            self._schedule_survey_notifications(survey)
+
+            if data.get('scheduled'):
+                scheduled_surveys = storage.get_setting('scheduled_surveys', [])
+                scheduled_surveys.append({
+                    'survey_id': survey_id,
+                    'scheduled_time': data['scheduled_datetime'],
+                    'created_by': data['creator_id'],
+                    'created_at': datetime.now().isoformat()
+                })
+                storage.set_setting('scheduled_surveys', scheduled_surveys)
+                try:
+                    from plugins import scheduler_plugin
+                    if getattr(scheduler_plugin, 'scheduler_instance', None):
+                        scheduler_plugin.scheduler_instance._create_scheduled_task(
+                            survey_id,
+                            datetime.fromisoformat(data['scheduled_datetime'])
+                        )
+                except Exception:
+                    pass
+            else:
+                self._schedule_survey_notifications(survey)
+
             await state.clear()
             await message.answer(f"✅ Опрос '{data['title']}' успешно создан!")
         else:
@@ -318,7 +392,12 @@ class SurveyPlugin:
             return
 
         for survey_id, survey in user_surveys.items():
-            status = "Активен" if survey['status'] == 'active' else "Завершен"
+            if survey['status'] == 'active':
+                status = "Активен"
+            elif survey['status'] == 'scheduled':
+                status = "Запланирован"
+            else:
+                status = "Завершен"
             deadline = datetime.fromisoformat(survey['deadline'])
             remaining = (deadline - datetime.now()).total_seconds() / 3600
 
@@ -444,6 +523,10 @@ class SurveyPlugin:
         deadline = datetime.fromisoformat(data['deadline'])
         summary += f"\nСрок действия: до {deadline.strftime('%d.%m.%Y %H:%M')}\n"
         summary += f"Анонимный: {'Да' if data.get('is_anonymous', False) else 'Нет'}"
+
+        if data.get('scheduled') and data.get('scheduled_datetime'):
+            dt = datetime.fromisoformat(data['scheduled_datetime'])
+            summary += f"\nЗапланировано на: {dt.strftime('%d.%m.%Y %H:%M')}"
 
         return summary
 

--- a/tests/test_scheduler_restore.py
+++ b/tests/test_scheduler_restore.py
@@ -1,0 +1,47 @@
+import importlib
+import asyncio
+from datetime import datetime, timedelta
+
+class DummyStorage:
+    def __init__(self):
+        self.settings = {}
+    def get_survey(self, survey_id):
+        return {
+            'deadline': (datetime.now() + timedelta(hours=2)).isoformat(),
+            'target_chats': []
+        }
+    def save_survey(self, survey_id, data):
+        pass
+    def get_setting(self, key, default=None):
+        return self.settings.get(key, default)
+    def set_setting(self, key, value):
+        self.settings[key] = value
+
+def test_restore_scheduled(monkeypatch):
+    storage = DummyStorage()
+    future = datetime.now() + timedelta(hours=1)
+    storage.set_setting('scheduled_surveys', [{
+        'survey_id': 's1',
+        'scheduled_time': future.isoformat(),
+        'created_by': 1,
+        'created_at': datetime.now().isoformat()
+    }])
+
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import plugins.scheduler_plugin as scheduler_plugin
+
+    tasks = []
+    def fake_create_task(coro):
+        tasks.append(coro)
+        class Dummy: pass
+        return Dummy()
+    monkeypatch.setattr(asyncio, 'create_task', fake_create_task)
+
+    module = importlib.reload(importlib.import_module('plugins.scheduler_plugin'))
+    monkeypatch.setattr(module, 'storage', storage, raising=False)
+    plugin = module.load_plugin()
+    plugin.on_plugin_load()
+
+    assert 's1' in plugin.scheduled_tasks


### PR DESCRIPTION
## Summary
- add schedule date/time states and handling in survey plugin
- store future survey send time and pass it to scheduler
- extend scheduler plugin with task restoration helper and deadline reminders
- provide global scheduler instance for access by other plugins
- test restoring scheduled surveys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668b088bac832abfc779320edf1549