### PR TITLE
Inject bot into scheduler plugin

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ async def main():
     dp = Dispatcher()
 
     # Инициализация менеджера плагинов
-    plugin_manager = PluginManager(dp)
+    plugin_manager = PluginManager(dp, bot)
 
     # Загружаем плагины
     await plugin_manager.load_plugins()

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -6,6 +6,7 @@
 """
 
 import importlib
+import inspect
 import os
 import logging
 from typing import Dict, List, Any, Optional
@@ -18,8 +19,9 @@ logger = logging.getLogger(__name__)
 class PluginManager:
     """Управляет всеми плагинами бота"""
     
-    def __init__(self, dp: Dispatcher):
+    def __init__(self, dp: Dispatcher, bot: Bot):
         self.dp = dp
+        self.bot = bot
         self.plugins = {}
         self.plugin_dir = "plugins"
         
@@ -43,7 +45,10 @@ class PluginManager:
             
         try:
             module = importlib.import_module(f"{self.plugin_dir}.{plugin_name}")
-            plugin = module.load_plugin()
+            if 'bot' in inspect.signature(module.load_plugin).parameters:
+                plugin = module.load_plugin(self.bot)
+            else:
+                plugin = module.load_plugin()
             
             # Регистрируем обработчики плагина
             await plugin.register_handlers(self.dp)

--- a/plugins/scheduler_plugin.py
+++ b/plugins/scheduler_plugin.py
@@ -9,7 +9,7 @@ import asyncio
 import datetime
 import logging
 
-from aiogram import Dispatcher, types
+from aiogram import Dispatcher, types, Bot
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext        # <-- Вместо dispatcher.FSMContext
 from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.filters.state
@@ -40,12 +40,13 @@ class SchedulerStates(StatesGroup):
 class SchedulerPlugin:
     """Плагин для планирования опросов и отправки сообщений по расписанию"""
 
-    def __init__(self):
+    def __init__(self, bot: "Bot"):
         self.name = "scheduler_plugin"
         self.description = "Scheduling functionality for surveys"
         self.scheduled_tasks = {}
         self.reminder_tasks = {}
         self.close_tasks = {}
+        self.bot = bot
 
     async def register_handlers(self, dp: Dispatcher):
         """
@@ -335,8 +336,8 @@ class SchedulerPlugin:
                 logger.warning(f"No target chats for scheduled survey {survey_id}")
                 return
 
-            # Берём bot из Dispatcher
-            bot = Dispatcher.get_current().bot
+            # Используем сохранённый экземпляр бота
+            bot = self.bot
 
             # Отправляем опрос в каждый чат
             for chat_id in target_chats:
@@ -388,7 +389,7 @@ class SchedulerPlugin:
                 logger.error(f"Survey {survey_id} for reminder not found")
                 return
 
-            bot = Dispatcher.get_current().bot
+            bot = self.bot
             target_chats = survey.get('target_chats', [])
 
             # Рассылаем напоминания по чатам
@@ -512,8 +513,8 @@ class SchedulerPlugin:
         logger.info("Scheduler plugin unloaded")
 
 
-def load_plugin():
+def load_plugin(bot: Bot):
     """Функция для загрузки плагина (aiogram-style)"""
     global scheduler_instance
-    scheduler_instance = SchedulerPlugin()
+    scheduler_instance = SchedulerPlugin(bot)
     return scheduler_instance

--- a/tests/test_scheduler_restore.py
+++ b/tests/test_scheduler_restore.py
@@ -17,6 +17,14 @@ class DummyStorage:
     def set_setting(self, key, value):
         self.settings[key] = value
 
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text))
+
 def test_restore_scheduled(monkeypatch):
     storage = DummyStorage()
     future = datetime.now() + timedelta(hours=1)
@@ -41,7 +49,48 @@ def test_restore_scheduled(monkeypatch):
 
     module = importlib.reload(importlib.import_module('plugins.scheduler_plugin'))
     monkeypatch.setattr(module, 'storage', storage, raising=False)
-    plugin = module.load_plugin()
+    bot = DummyBot()
+    plugin = module.load_plugin(bot)
     plugin.on_plugin_load()
 
     assert 's1' in plugin.scheduled_tasks
+
+
+def test_scheduled_send(monkeypatch):
+    storage = DummyStorage()
+    storage.surveys = {
+        's1': {
+            'title': 'T',
+            'description': 'D',
+            'deadline': (datetime.now() + timedelta(hours=1)).isoformat(),
+            'target_chats': [42],
+            'status': 'pending',
+        }
+    }
+    storage.settings['scheduled_surveys'] = [{'survey_id': 's1'}]
+    monkeypatch.setattr(storage, 'get_survey', lambda sid: storage.surveys.get(sid))
+
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+    module = importlib.reload(importlib.import_module('plugins.scheduler_plugin'))
+    monkeypatch.setattr(module, 'storage', storage, raising=False)
+
+    bot = DummyBot()
+    plugin = module.load_plugin(bot)
+
+    async def fake_sleep(delay):
+        pass
+
+    monkeypatch.setattr(module.asyncio, 'sleep', fake_sleep)
+    def fake_task(coro):
+        class Dummy:
+            def cancel(self):
+                pass
+        return Dummy()
+    monkeypatch.setattr(module.asyncio, 'create_task', fake_task)
+
+    asyncio.run(plugin._send_scheduled_survey('s1', 0))
+
+    assert bot.sent


### PR DESCRIPTION
## Summary
- pass bot instance to `SchedulerPlugin` on plugin load
- keep bot reference inside scheduler plugin and use it for scheduled tasks
- modify `PluginManager` to forward bot to plugins that request it
- adapt `main.py` to supply bot when creating `PluginManager`
- test sending of a scheduled message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dd1a4b6c832ab43290f573d24195