### PR TITLE
Implement pinning for survey messages

### DIFF
--- a/plugins/scheduler_plugin.py
+++ b/plugins/scheduler_plugin.py
@@ -348,11 +348,12 @@ class SchedulerPlugin:
                         callback_data=f"start_survey_{survey_id}"
                     )
                     markup = builder.as_markup()
-                    await bot.send_message(
+                    msg = await bot.send_message(
                         chat_id,
                         f"📊 Новый опрос: {survey.get('title')}\n\n{survey.get('description', '')}",
                         reply_markup=markup
                     )
+                    await self._try_pin(chat_id, msg.message_id)
                 except Exception as e:
                     logger.error(f"Failed to send survey to chat {chat_id}: {e}")
 
@@ -421,6 +422,19 @@ class SchedulerPlugin:
             logger.info(f"Close task for survey {survey_id} was cancelled")
         except Exception as e:
             logger.error(f"Error closing survey {survey_id}: {e}")
+
+    async def _try_pin(self, chat_id: int, message_id: int):
+        """Пытается закрепить сообщение, если у бота есть такие права"""
+        try:
+            me = await self.bot.get_me()
+            member = await self.bot.get_chat_member(chat_id, me.id)
+            can_pin = getattr(member, 'can_pin_messages', False) or member.status == 'creator'
+            if can_pin:
+                await self.bot.pin_chat_message(chat_id=chat_id, message_id=message_id, disable_notification=False)
+            else:
+                logger.warning(f"Bot has no rights to pin messages in chat {chat_id}")
+        except Exception as e:
+            logger.error(f"Failed to pin message in chat {chat_id}: {e}")
 
     async def cmd_list_scheduled(self, message: types.Message):
         """Обработка команды /scheduled — список запланированных опросов для данного пользователя"""

--- a/tests/test_scheduler_restore.py
+++ b/tests/test_scheduler_restore.py
@@ -21,9 +21,30 @@ class DummyStorage:
 class DummyBot:
     def __init__(self):
         self.sent = []
+        self.pinned = []
+        self.id = 99
 
     async def send_message(self, chat_id, text, **kwargs):
         self.sent.append((chat_id, text))
+        class DummyMsg:
+            def __init__(self, message_id):
+                self.message_id = message_id
+        return DummyMsg(len(self.sent))
+
+    async def get_me(self):
+        class Me:
+            def __init__(self, id_):
+                self.id = id_
+        return Me(self.id)
+
+    async def get_chat_member(self, chat_id, user_id):
+        class Member:
+            status = 'administrator'
+            can_pin_messages = True
+        return Member()
+
+    async def pin_chat_message(self, chat_id, message_id, **kwargs):
+        self.pinned.append((chat_id, message_id))
 
 def test_restore_scheduled(monkeypatch):
     storage = DummyStorage()
@@ -94,3 +115,5 @@ def test_scheduled_send(monkeypatch):
     asyncio.run(plugin._send_scheduled_survey('s1', 0))
 
     assert bot.sent
+    assert bot.pinned
+


### PR DESCRIPTION
## Summary
- pin survey announcements in `scheduler_plugin`
- check pinning permissions and log outcomes
- extend scheduler plugin tests to confirm pinning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a3528a74832a8a64456c2e88db8e