### PR TITLE
Extend admin menu interactions

### DIFF
--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -35,6 +35,18 @@ class AdminMenuPlugin:
         # Загружаем admin_ids из переменной окружения с помощью regex
         ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
         self.admin_ids = [int(x) for x in ids]
+        # Экземпляры вспомогательных плагинов
+        from plugins.survey_plugin import SurveyPlugin
+        from plugins.export_plugin import ExportPlugin
+        from plugins.test_mode_plugin import TestModePlugin
+        from plugins.survey_templates_plugin import SurveyTemplatesPlugin
+        from plugins.roles_plugin import RolesPlugin
+
+        self.survey_plugin = SurveyPlugin()
+        self.export_plugin = ExportPlugin()
+        self.test_mode_plugin = TestModePlugin()
+        self.templates_plugin = SurveyTemplatesPlugin()
+        self.roles_plugin = RolesPlugin()
     
     async def register_handlers(self, dp: Dispatcher):
         """Регистрирует все обработчики для плагина"""
@@ -51,6 +63,36 @@ class AdminMenuPlugin:
             self.handle_back,
             lambda msg: msg.text == "🔙 Назад",
             StateFilter(AdminMenuStates.SURVEYS_MENU, AdminMenuStates.ANALYTICS_MENU, AdminMenuStates.SETTINGS_MENU)
+        )
+        dp.message.register(
+            self.handle_surveys_menu,
+            lambda msg: msg.text in [
+                "Создать опрос",
+                "Мои опросы",
+                "Шаблоны вопросов",
+                "Настройки опросов",
+            ],
+            StateFilter(AdminMenuStates.SURVEYS_MENU),
+        )
+        dp.message.register(
+            self.handle_analytics_menu,
+            lambda msg: msg.text in [
+                "Статистика опросов",
+                "Экспорт данных",
+                "Активность группы",
+                "Рейтинги",
+            ],
+            StateFilter(AdminMenuStates.ANALYTICS_MENU),
+        )
+        dp.message.register(
+            self.handle_settings_menu,
+            lambda msg: msg.text in [
+                "Общие настройки",
+                "Настройки уведомлений",
+                "Управление доступом",
+                "Тестовый режим",
+            ],
+            StateFilter(AdminMenuStates.SETTINGS_MENU),
         )
     
     def get_commands(self):
@@ -118,6 +160,37 @@ class AdminMenuPlugin:
         elif message.text == "⚙ Настройки":
             await state.set_state(AdminMenuStates.SETTINGS_MENU)
             await message.answer("Меню настроек:", reply_markup=self.get_keyboards()['admin_settings'])
+
+    async def handle_surveys_menu(self, message: types.Message, state: FSMContext):
+        """Выбор пунктов в меню опросов"""
+        if message.text == "Создать опрос":
+            await self.survey_plugin.cmd_create_survey(message, state)
+        elif message.text == "Мои опросы":
+            await self.survey_plugin.cmd_view_surveys(message, state)
+        elif message.text == "Шаблоны вопросов":
+            await self.templates_plugin.cmd_list_templates(message)
+        elif message.text == "Настройки опросов":
+            await message.answer("Функция в разработке")
+
+    async def handle_analytics_menu(self, message: types.Message, state: FSMContext):
+        """Выбор пунктов в меню аналитики"""
+        if message.text == "Экспорт данных":
+            await self.export_plugin.cmd_export(message)
+        elif message.text == "Статистика опросов":
+            await message.answer("Функция в разработке")
+        elif message.text == "Активность группы":
+            await message.answer("Функция в разработке")
+        elif message.text == "Рейтинги":
+            await message.answer("Функция в разработке")
+
+    async def handle_settings_menu(self, message: types.Message, state: FSMContext):
+        """Выбор пунктов в меню настроек"""
+        if message.text == "Тестовый режим":
+            await self.test_mode_plugin.cmd_test_mode(message, state)
+        elif message.text == "Управление доступом":
+            await self.roles_plugin.cmd_roles(message, state)
+        else:
+            await message.answer("Функция в разработке")
     
     async def handle_back(self, message: types.Message, state: FSMContext):
         """Обрабатывает кнопку 'Назад'"""

--- a/tests/test_admin_menu.py
+++ b/tests/test_admin_menu.py
@@ -1,0 +1,51 @@
+import importlib
+import asyncio
+
+class DummyUser:
+    def __init__(self, id_):
+        self.id = id_
+
+class DummyMessage:
+    def __init__(self, text, user_id=1):
+        self.text = text
+        self.from_user = DummyUser(user_id)
+        self.responses = []
+
+    async def answer(self, text, **kwargs):
+        self.responses.append(text)
+
+class DummyState:
+    def __init__(self):
+        self.state = None
+
+    async def set_state(self, state):
+        self.state = state
+
+
+def test_admin_menu_calls(monkeypatch):
+    adm_module = importlib.reload(importlib.import_module('plugins.admin_menu_plugin'))
+    plugin = adm_module.load_plugin()
+
+    called = {}
+
+    async def fake_create(msg, state):
+        called['create'] = msg.text
+    monkeypatch.setattr(plugin.survey_plugin, 'cmd_create_survey', fake_create)
+
+    async def fake_export(msg):
+        called['export'] = msg.text
+    monkeypatch.setattr(plugin.export_plugin, 'cmd_export', fake_export)
+
+    async def fake_test_mode(msg, state):
+        called['test_mode'] = msg.text
+    monkeypatch.setattr(plugin.test_mode_plugin, 'cmd_test_mode', fake_test_mode)
+
+    state = DummyState()
+    msg = DummyMessage('Создать опрос')
+    asyncio.run(plugin.handle_surveys_menu(msg, state))
+    msg = DummyMessage('Экспорт данных')
+    asyncio.run(plugin.handle_analytics_menu(msg, state))
+    msg = DummyMessage('Тестовый режим')
+    asyncio.run(plugin.handle_settings_menu(msg, state))
+
+    assert called == {'create': 'Создать опрос', 'export': 'Экспорт данных', 'test_mode': 'Тестовый режим'}


### PR DESCRIPTION
## Summary
- wire up admin menu options to call other plugins
- create tests for admin menu callbacks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6867aa7a32a0832aa5c9441e1e7257e5