### PR TITLE
Add response logging to polls

### DIFF
--- a/core/db_manager.py
+++ b/core/db_manager.py
@@ -93,6 +93,18 @@ def initialize_db():
             PRIMARY KEY (user_id, chat_id)
         )
     ''')
+    # Таблица ответов пользователей на вопросы опросов
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS responses (
+            poll_id INTEGER,
+            question_id INTEGER,
+            user_id INTEGER,
+            answer TEXT,
+            timestamp DATETIME,
+            FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE,
+            FOREIGN KEY (question_id) REFERENCES questions(id) ON DELETE CASCADE
+        )
+    ''')
     # Настройки: тестовый режим, приветствие
     cursor.execute('''
         INSERT OR IGNORE INTO settings (key, value) VALUES ('test_mode', '0')
@@ -445,3 +457,39 @@ def get_scheduled_surveys() -> List[Dict]:
         })
     conn.close()
     return polls
+
+# --- Responses ---
+def add_response(poll_id: int, question_id: int, user_id: Optional[int], answer: str, timestamp: datetime):
+    """Сохраняет ответ пользователя на вопрос."""
+    conn = sqlite3.connect(DATABASE)
+    cursor = conn.cursor()
+    ts = timestamp.strftime("%Y-%m-%d %H:%M:%S") if isinstance(timestamp, datetime) else str(timestamp)
+    cursor.execute(
+        'INSERT INTO responses (poll_id, question_id, user_id, answer, timestamp) VALUES (?, ?, ?, ?, ?)',
+        (poll_id, question_id, user_id, answer, ts)
+    )
+    conn.commit()
+    conn.close()
+    logger.info(f"Response added for poll {poll_id}, question {question_id}.")
+
+
+def get_responses_by_poll(poll_id: int) -> List[Dict]:
+    """Возвращает все ответы для указанного опроса."""
+    conn = sqlite3.connect(DATABASE)
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT poll_id, question_id, user_id, answer, timestamp FROM responses WHERE poll_id = ?',
+        (poll_id,)
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    responses = []
+    for row in rows:
+        responses.append({
+            'poll_id': row[0],
+            'question_id': row[1],
+            'user_id': row[2],
+            'answer': row[3],
+            'timestamp': row[4],
+        })
+    return responses

--- a/handlers/survey_handlers.py
+++ b/handlers/survey_handlers.py
@@ -6,7 +6,12 @@ from aiogram import Router, Bot, types
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.filters import Command, StateFilter
 from aiogram.fsm.context import FSMContext
-from core.db_manager import get_poll_by_id, get_welcome_message, update_user_activity
+from core.db_manager import (
+    get_poll_by_id,
+    get_welcome_message,
+    update_user_activity,
+    add_response,
+)
 from plugins.survey_plugin import get_questions
 from utils.data_manager import save_to_excel
 
@@ -35,8 +40,8 @@ async def send_question(user_id: int, bot: Bot, state: FSMContext):
         return
 
     question = questions[current_index]
-    # Сохраняем текущий текст вопроса (для текстовых ответов)
-    await state.update_data(current_question_text=question['text'])
+    # Сохраняем текущий текст и id вопроса (для текстовых ответов)
+    await state.update_data(current_question_text=question['text'], current_question_id=question['id'])
     question_text = question['text']
     q_type = question['type']
     options = question['options']
@@ -129,6 +134,9 @@ async def answer_callback_handler(callback_query: types.CallbackQuery, state: FS
     responses = current_data.get('responses', [])
     responses.append({"question": question['text'], "answer": option})
     await state.update_data(responses=responses, current_question_index=q_index + 1)
+    poll_info = get_poll_by_id(poll_id)
+    db_user_id = None if poll_info and poll_info.get("anonymous") else callback_query.from_user.id
+    add_response(poll_id, question['id'], db_user_id, option, datetime.utcnow())
     await bot.send_message(callback_query.from_user.id, f"Вы выбрали: {option}")
     await send_question(callback_query.from_user.id, bot, state)
 
@@ -194,6 +202,9 @@ async def confirm_multiple_handler(callback_query: types.CallbackQuery, state: F
     responses = current_data.get('responses', [])
     responses.append({"question": question['text'], "answer": answer_text})
     await state.update_data(responses=responses, current_question_index=q_index + 1)
+    poll_info = get_poll_by_id(poll_id)
+    db_user_id = None if poll_info and poll_info.get("anonymous") else callback_query.from_user.id
+    add_response(poll_id, question['id'], db_user_id, answer_text, datetime.utcnow())
     selected_options_all = current_data.get('selected_options', {})
     selected_options_all[str(q_index)] = []
     await state.update_data(selected_options=selected_options_all)
@@ -222,9 +233,15 @@ async def handle_text_answer(message: types.Message, state: FSMContext, bot: Bot
     answer = message.text.strip()
     data = await state.get_data()
     current_question_text = data.get('current_question_text', "Неизвестный вопрос")
+    question_id = data.get('current_question_id')
     responses = data.get('responses', [])
     responses.append({"question": current_question_text, "answer": answer})
     await state.update_data(responses=responses)
+    poll_id = data.get('poll_id')
+    poll_info = get_poll_by_id(poll_id)
+    db_user_id = None if poll_info and poll_info.get("anonymous") else user_id
+    if question_id is not None:
+        add_response(poll_id, question_id, db_user_id, answer, datetime.utcnow())
     await send_question(user_id, bot, state)
 
 def register_survey_handlers(dp: Bot):

--- a/plugins/multiple_choice_plugin.py
+++ b/plugins/multiple_choice_plugin.py
@@ -10,6 +10,7 @@ import logging
 from aiogram import Dispatcher
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import CallbackQuery
+from core.db_manager import add_response
 
 # Поправленные импорты для хранилища
 try:
@@ -178,6 +179,7 @@ class MultipleChoicePlugin:
 
         # Добавляем или обновляем ответ
         self._add_or_update_response(survey, user_id, question_id, response)
+        add_response(survey_id, question_id, response['user_id'], ','.join(map(str, selections)), callback_query.message.date)
         storage.save_survey(survey_id, survey)
 
         # Очищаем выбор пользователя

--- a/plugins/single_choice_plugin.py
+++ b/plugins/single_choice_plugin.py
@@ -4,6 +4,7 @@
 
 from aiogram import Dispatcher, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from core.db_manager import add_response
 import logging
 
 try:
@@ -64,6 +65,7 @@ class SingleChoicePlugin:
             'timestamp': callback_query.message.date.isoformat()
         }
         self._add_or_update_response(survey, user_id, question_id, response)
+        add_response(survey_id, question_id, response['user_id'], option_index, callback_query.message.date)
         storage.save_survey(survey_id, survey)
         question = next((q for q in survey['questions'] if q['id'] == question_id), None)
         if question:

--- a/plugins/text_answer_plugin.py
+++ b/plugins/text_answer_plugin.py
@@ -11,6 +11,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import StateFilter  # Добавляем фильтр состояния
 import logging
+from core.db_manager import add_response
 
 # Импорт хранилища из storage_plugin
 try:
@@ -131,9 +132,10 @@ class TextAnswerPlugin:
             'answer': message.text,
             'timestamp': message.date.isoformat()
         }
-        
+
         # Добавляем либо обновляем ответ
         self._add_or_update_response(survey, user_id, question_id, response)
+        add_response(survey_id, question_id, response['user_id'], message.text, message.date)
         storage.save_survey(survey_id, survey)
         
         await message.reply("✅ Ваш ответ записан! Спасибо за участие.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,106 @@
+import sys, types
+
+# Minimal aiogram stubs for plugin imports
+aiogram = types.ModuleType('aiogram')
+aiogram.Dispatcher = type('Dispatcher', (), {})
+aiogram.Bot = type('Bot', (), {})
+class _Handler:
+    def __call__(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+    def register(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+class Router:
+    def __init__(self):
+        self.message = _Handler()
+        self.callback_query = _Handler()
+    def include_router(self, *args, **kwargs):
+        pass
+
+aiogram.Router = Router
+
+# submodule: types
+types_mod = types.ModuleType('aiogram.types')
+types_mod.BotCommand = type('BotCommand', (), {})
+types_mod.CallbackQuery = type('CallbackQuery', (), {'data': ''})
+types_mod.Message = type('Message', (), {})
+class ChatPermissions:
+    def __init__(self, **kwargs):
+        self.permissions = kwargs
+types_mod.ChatPermissions = ChatPermissions
+def _getattr(name):
+    cls = type(name, (), {})
+    setattr(types_mod, name, cls)
+    return cls
+types_mod.__getattr__ = _getattr
+aiogram.types = types_mod
+
+# submodule: filters
+filters_mod = types.ModuleType('aiogram.filters')
+class Command:
+    def __init__(self, *args, **kwargs):
+        pass
+class StateFilter:
+    def __init__(self, *args, **kwargs):
+        pass
+class ChatMemberUpdatedFilter:
+    def __init__(self, *args, **kwargs):
+        pass
+filters_mod.Command = Command
+filters_mod.StateFilter = StateFilter
+filters_mod.ChatMemberUpdatedFilter = ChatMemberUpdatedFilter
+aiogram.filters = filters_mod
+
+# FSM context/state
+fsm_mod = types.ModuleType('aiogram.fsm')
+context_mod = types.ModuleType('aiogram.fsm.context')
+context_mod.FSMContext = type('FSMContext', (), {})
+state_mod = types.ModuleType('aiogram.fsm.state')
+state_mod.State = type('State', (), {})
+state_mod.StatesGroup = type('StatesGroup', (), {})
+fsm_mod.context = context_mod
+fsm_mod.state = state_mod
+aiogram.fsm = fsm_mod
+
+# utils.keyboard
+utils_mod = types.ModuleType('aiogram.utils')
+keyboard_mod = types.ModuleType('aiogram.utils.keyboard')
+class _Builder:
+    def button(self, **kwargs):
+        pass
+    def adjust(self, *args, **kwargs):
+        pass
+    def as_markup(self):
+        return None
+keyboard_mod.InlineKeyboardBuilder = _Builder
+utils_mod.keyboard = keyboard_mod
+aiogram.utils = utils_mod
+
+client_bot_mod = types.ModuleType('aiogram.client.bot')
+client_bot_mod.Bot = aiogram.Bot
+
+sys.modules.setdefault('aiogram', aiogram)
+sys.modules.setdefault('aiogram.types', types_mod)
+sys.modules.setdefault('aiogram.filters', filters_mod)
+sys.modules.setdefault('aiogram.fsm', fsm_mod)
+sys.modules.setdefault('aiogram.fsm.context', context_mod)
+sys.modules.setdefault('aiogram.fsm.state', state_mod)
+sys.modules.setdefault('aiogram.utils', utils_mod)
+sys.modules.setdefault('aiogram.utils.keyboard', keyboard_mod)
+sys.modules.setdefault('aiogram.client.bot', client_bot_mod)
+
+# Stubs for additional libraries
+dotenv_mod = types.ModuleType('dotenv')
+def load_dotenv(*args, **kwargs):
+    pass
+dotenv_mod.load_dotenv = load_dotenv
+sys.modules.setdefault('dotenv', dotenv_mod)
+
+pandas_mod = types.ModuleType('pandas')
+pandas_mod.DataFrame = type('DataFrame', (), {})
+sys.modules.setdefault('pandas', pandas_mod)
+sys.modules.setdefault('openpyxl', types.ModuleType('openpyxl'))

--- a/tests/test_db_responses.py
+++ b/tests/test_db_responses.py
@@ -1,0 +1,18 @@
+import importlib
+from datetime import datetime
+from pathlib import Path
+import sys
+
+def test_add_and_get_responses(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE", str(db_path))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    db_module = importlib.reload(importlib.import_module("core.db_manager"))
+    db_module.initialize_db()
+    poll_id = db_module.add_poll("Test")
+    db_module.add_question_to_poll(poll_id, "Q1", "Одиночный выбор", ["a", "b"])
+    question = db_module.get_questions_by_poll(poll_id)[0]
+    db_module.add_response(poll_id, question["id"], 123, "a", datetime.now())
+    responses = db_module.get_responses_by_poll(poll_id)
+    assert len(responses) == 1
+    assert responses[0]["answer"] == "a"


### PR DESCRIPTION
## Summary
- add `responses` table and helpers to `db_manager`
- log answers from survey handlers and question plugins
- stub external deps for tests
- test database response handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e8e54bc0832abcd660bbdbed63d9