### PR TITLE
Add 'Other' option support

### DIFF
--- a/plugins/export_plugin.py
+++ b/plugins/export_plugin.py
@@ -195,26 +195,39 @@ class ExportPlugin:
             if question.get("type") == "single_choice":
                 options = question.get("options", [])
                 counts = [0] * len(options)
+                other = 0
                 for response in question_responses:
                     answer = response.get("answer")
                     if isinstance(answer, int) and 0 <= answer < len(options):
                         counts[answer] += 1
-                total = sum(counts)
+                    else:
+                        other += 1
+                total = sum(counts) + other
                 for i, option in enumerate(options):
                     percentage = (counts[i] / total * 100) if total > 0 else 0
                     report.append(f"  {option}: {counts[i]} ({percentage:.1f}%)")
+                if other:
+                    percentage = (other / total * 100) if total > 0 else 0
+                    report.append(f"  Другое: {other} ({percentage:.1f}%)")
             elif question.get("type") == "multiple_choice":
                 options = question.get("options", [])
                 counts = [0] * len(options)
+                other = 0
                 for response in question_responses:
                     answer = response.get("answer", [])
                     if isinstance(answer, list):
                         for option_index in answer:
                             if 0 <= option_index < len(options):
                                 counts[option_index] += 1
+                    else:
+                        other += 1
+                total = len(question_responses)
                 for i, option in enumerate(options):
-                    percentage = (counts[i] / len(question_responses) * 100) if question_responses else 0
+                    percentage = (counts[i] / total * 100) if total else 0
                     report.append(f"  {option}: {counts[i]} ({percentage:.1f}%)")
+                if other:
+                    percentage = (other / total * 100) if total else 0
+                    report.append(f"  Другое: {other} ({percentage:.1f}%)")
             elif question.get("type") == "text_answer":
                 report.append("Текстовые ответы:")
                 for i, response in enumerate(question_responses):

--- a/plugins/multiple_choice_plugin.py
+++ b/plugins/multiple_choice_plugin.py
@@ -9,7 +9,7 @@ import logging
 
 from aiogram import Dispatcher
 from aiogram.utils.keyboard import InlineKeyboardBuilder
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, Message
 from core.db_manager import add_response
 
 # Поправленные импорты для хранилища
@@ -43,6 +43,7 @@ class MultipleChoicePlugin:
             self.process_multiple_choice_submit,
             lambda c: c.data.startswith('multi_submit_')
         )
+        dp.message.register(self.process_other_input)
 
     def get_commands(self):
         """Возвращает список команд плагина"""
@@ -104,6 +105,16 @@ class MultipleChoicePlugin:
 
         user_id = callback_query.from_user.id
 
+        question = next((q for q in survey['questions'] if q['id'] == question_id), None)
+        if question and question['options'][option_index].startswith('Другое'):
+            state = storage.get_user_state(user_id)
+            state[f'multi_other_{survey_id}_{question_id}'] = True
+            storage.set_user_state(user_id, f'multi_other_{survey_id}_{question_id}', True)
+            storage.set_user_state(user_id, f"multi_{survey_id}_{question_id}", None)
+            await callback_query.message.answer('Пожалуйста, введите свой вариант:')
+            await callback_query.answer()
+            return
+
         # Получаем или создаём выбор пользователя для данного вопроса
         user_state = storage.get_user_state(user_id)
         selection_key = f"multi_{survey_id}_{question_id}"
@@ -160,6 +171,11 @@ class MultipleChoicePlugin:
 
         user_id = callback_query.from_user.id
 
+        # Проверяем, не ожидается ли текстовый вариант
+        if storage.get_user_state(user_id).get(f'multi_other_{survey_id}_{question_id}'):
+            await callback_query.answer("Пожалуйста, сначала введите свой вариант")
+            return
+
         # Получаем выбор пользователя
         user_state = storage.get_user_state(user_id)
         selection_key = f"multi_{survey_id}_{question_id}"
@@ -193,6 +209,29 @@ class MultipleChoicePlugin:
             f"{old_text}\n\n✅ Ваш ответ принят!"
         )
 
+    async def process_other_input(self, message: Message):
+        user_id = message.from_user.id
+        state = storage.get_user_state(user_id)
+        key = next((k for k in state.keys() if k.startswith('multi_other_')), None)
+        if not key:
+            return
+        survey_id, question_id = key.split('_')[2], key.split('_')[3]
+        survey = storage.get_survey(survey_id)
+        if not survey or survey['status'] != 'active':
+            storage.set_user_state(user_id, key, None)
+            return
+        response = {
+            'user_id': None if survey.get('is_anonymous') else user_id,
+            'question_id': question_id,
+            'answer': message.text,
+            'timestamp': message.date.isoformat(),
+        }
+        self._add_or_update_response(survey, user_id, question_id, response)
+        add_response(survey_id, question_id, response['user_id'], message.text, message.date)
+        storage.save_survey(survey_id, survey)
+        storage.set_user_state(user_id, key, None)
+        await message.answer("✅ Ваш ответ записан!")
+
     def _add_or_update_response(self, survey, user_id, question_id, new_response):
         """Добавляет или обновляет ответ в опросе"""
         # Для анонимных опросов всегда добавляем новый ответ
@@ -214,12 +253,16 @@ class MultipleChoicePlugin:
         """Обрабатывает результаты для этого типа вопроса"""
         options = question['options']
         counts = [0] * len(options)
+        other = 0
 
         for response in responses:
-            if isinstance(response.get('answer'), list):
-                for option_index in response['answer']:
+            ans = response.get('answer')
+            if isinstance(ans, list):
+                for option_index in ans:
                     if 0 <= option_index < len(options):
                         counts[option_index] += 1
+            else:
+                other += 1
 
         total_responses = len(responses)
         results = {
@@ -236,6 +279,10 @@ class MultipleChoicePlugin:
                 'count': counts[i],
                 'percentage': round(percentage, 1)
             })
+
+        if other:
+            percentage = (other / total_responses * 100) if total_responses > 0 else 0
+            results['options'].append({'text': 'Другое', 'count': other, 'percentage': round(percentage, 1)})
 
         return results
 

--- a/plugins/single_choice_plugin.py
+++ b/plugins/single_choice_plugin.py
@@ -17,12 +17,18 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+OTHER_OPTION = "Другое…"
+
 class SingleChoicePlugin:
     def __init__(self):
         self.name = "single_choice_plugin"
         self.description = "Тип вопроса - одиночный выбор"
     async def register_handlers(self, dp: Dispatcher):
-        dp.callback_query.register(self.process_single_choice_selection, lambda c: c.data.startswith('single_choice_'))
+        dp.callback_query.register(
+            self.process_single_choice_selection,
+            lambda c: c.data.startswith('single_choice_')
+        )
+        dp.message.register(self.process_other_input)
     def get_commands(self):
         return []
     def get_question_type(self):
@@ -58,6 +64,15 @@ class SingleChoicePlugin:
             await callback_query.answer("Этот опрос недоступен")
             return
         user_id = callback_query.from_user.id
+        question = next((q for q in survey['questions'] if q['id'] == question_id), None)
+        if question and question['options'][option_index].startswith('Другое'):
+            state = storage.get_user_state(user_id)
+            state['single_other'] = {'survey_id': survey_id, 'question_id': question_id}
+            storage.set_user_state(user_id, 'single_other', state['single_other'])
+            await callback_query.message.answer('Пожалуйста, введите свой вариант:')
+            await callback_query.answer()
+            return
+
         response = {
             'user_id': None if survey['is_anonymous'] else user_id,
             'question_id': question_id,
@@ -67,7 +82,6 @@ class SingleChoicePlugin:
         self._add_or_update_response(survey, user_id, question_id, response)
         add_response(survey_id, question_id, response['user_id'], option_index, callback_query.message.date)
         storage.save_survey(survey_id, survey)
-        question = next((q for q in survey['questions'] if q['id'] == question_id), None)
         if question:
             options = question['options']
             builder = InlineKeyboardBuilder()
@@ -81,6 +95,30 @@ class SingleChoicePlugin:
             markup = builder.as_markup()
             await callback_query.message.edit_reply_markup(reply_markup=markup)
         await callback_query.answer("Ваш ответ записан!")
+
+    async def process_other_input(self, message: types.Message):
+        user_id = message.from_user.id
+        state = storage.get_user_state(user_id)
+        data = state.get('single_other')
+        if not data:
+            return
+        survey_id = data['survey_id']
+        question_id = data['question_id']
+        survey = storage.get_survey(survey_id)
+        if not survey or survey['status'] != 'active':
+            storage.set_user_state(user_id, 'single_other', None)
+            return
+        response = {
+            'user_id': None if survey['is_anonymous'] else user_id,
+            'question_id': question_id,
+            'answer': message.text,
+            'timestamp': message.date.isoformat()
+        }
+        self._add_or_update_response(survey, user_id, question_id, response)
+        add_response(survey_id, question_id, response['user_id'], message.text, message.date)
+        storage.save_survey(survey_id, survey)
+        storage.set_user_state(user_id, 'single_other', None)
+        await message.answer("✅ Ваш ответ записан!")
     def _add_or_update_response(self, survey, user_id, question_id, new_response):
         if survey['is_anonymous']:
             survey['responses'].append(new_response)

--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -648,18 +648,30 @@ class SurveyPlugin:
             else:
                 options = question['options']
                 counts = [0] * len(options)
+                other = 0
                 for response in survey['responses']:
                     if response['question_id'] == question['id']:
+                        ans = response['answer']
                         if question['type'] == "одиночный выбор":
-                            counts[response['answer']] += 1
+                            if isinstance(ans, int):
+                                counts[ans] += 1
+                            else:
+                                other += 1
                         else:
-                            for option_index in response['answer']:
-                                counts[option_index] += 1
-                total = sum(counts)
+                            if isinstance(ans, list):
+                                for option_index in ans:
+                                    if 0 <= option_index < len(options):
+                                        counts[option_index] += 1
+                            else:
+                                other += 1
+                total = sum(counts) + other
                 results += f"<b>Результаты ({total} ответов):</b>\n"
                 for i, option in enumerate(options):
                     percentage = (counts[i] / total * 100) if total > 0 else 0
                     results += f"{option}: {counts[i]} ({percentage:.1f}%)\n"
+                if other:
+                    percentage = (other / total * 100) if total > 0 else 0
+                    results += f"Другое: {other} ({percentage:.1f}%)\n"
             results += "\n"
 
         return results

--- a/tests/test_other_option.py
+++ b/tests/test_other_option.py
@@ -1,0 +1,96 @@
+import importlib, asyncio
+from datetime import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+class DummyStorage:
+    def __init__(self):
+        self.surveys = {}
+        self.user_state = {}
+    def get_survey(self, sid):
+        return self.surveys.get(sid)
+    def save_survey(self, sid, data):
+        self.surveys[sid] = data
+    def get_user_state(self, uid):
+        return self.user_state.setdefault(uid, {})
+    def set_user_state(self, uid, key, value):
+        state = self.user_state.setdefault(uid, {})
+        if value is None:
+            state.pop(key, None)
+        else:
+            state[key] = value
+
+class DummyMessage:
+    def __init__(self, text, user_id=1):
+        self.text = text
+        self.from_user = type('U', (), {'id': user_id})
+        self.date = datetime.now()
+        self.sent = []
+    async def answer(self, text, **kw):
+        self.sent.append(text)
+    async def edit_reply_markup(self, **kw):
+        pass
+
+class DummyCallback:
+    def __init__(self, data, user_id=1):
+        self.data = data
+        self.from_user = type('U', (), {'id': user_id})
+        self.message = DummyMessage('')
+    async def answer(self, *a, **kw):
+        pass
+
+
+def setup_single(monkeypatch):
+    mod = importlib.reload(importlib.import_module('plugins.single_choice_plugin'))
+    storage = DummyStorage()
+    monkeypatch.setattr(mod, 'storage', storage, raising=False)
+    called = []
+    monkeypatch.setattr(mod, 'add_response', lambda *a: called.append(a))
+    plugin = mod.load_plugin()
+    return plugin, storage, called
+
+
+def setup_multi(monkeypatch):
+    mod = importlib.reload(importlib.import_module('plugins.multiple_choice_plugin'))
+    storage = DummyStorage()
+    monkeypatch.setattr(mod, 'storage', storage, raising=False)
+    called = []
+    monkeypatch.setattr(mod, 'add_response', lambda *a: called.append(a))
+    plugin = mod.load_plugin()
+    return plugin, storage, called
+
+
+def test_single_other(monkeypatch):
+    plugin, storage, called = setup_single(monkeypatch)
+    survey = {
+        'id': 's1',
+        'status': 'active',
+        'is_anonymous': False,
+        'questions': [{'id': 'q1', 'text': 'Q', 'type': 'single_choice', 'options': ['A','Другое…']}],
+        'responses': []
+    }
+    storage.save_survey('s1', survey)
+    cb = DummyCallback('single_choice_s1_q1_1')
+    asyncio.run(plugin.process_single_choice_selection(cb))
+    assert storage.get_user_state(1).get('single_other')
+    msg = DummyMessage('X')
+    asyncio.run(plugin.process_other_input(msg))
+    assert survey['responses'][0]['answer'] == 'X'
+    assert called
+
+
+def test_generate_results_other(monkeypatch):
+    mod = importlib.reload(importlib.import_module('plugins.survey_plugin'))
+    plugin = mod.load_plugin()
+    survey = {
+        'title': 'T',
+        'questions': [{'id': 'q1', 'text': 'Q', 'type': 'одиночный выбор', 'options': ['A','Другое…']}],
+        'responses': [
+            {'question_id': 'q1', 'answer': 0},
+            {'question_id': 'q1', 'answer': 'X'}
+        ]
+    }
+    res = plugin._generate_results(survey)
+    assert 'Другое' in res


### PR DESCRIPTION
## Summary
- add special "Другое…" handling in single and multiple choice plugins
- store free-form answers via `add_response`
- include "Другое" counts in survey results and text exports
- add regression tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686840e02304832abcb0f15455bb1d6f