### PR TITLE
Add admin access denial test

### DIFF
--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -1,0 +1,30 @@
+import importlib
+import asyncio
+
+class DummyUser:
+    def __init__(self, id_):
+        self.id = id_
+
+class DummyMessage:
+    def __init__(self, text, user_id=1):
+        self.text = text
+        self.from_user = DummyUser(user_id)
+        self.responses = []
+
+    async def answer(self, text, **kwargs):
+        self.responses.append(text)
+
+class DummyState:
+    async def set_state(self, state):
+        pass
+
+def test_admin_access_denied(monkeypatch):
+    monkeypatch.setenv("ADMIN_IDS", "123")
+    adm_module = importlib.reload(importlib.import_module("plugins.admin_menu_plugin"))
+    plugin = adm_module.load_plugin()
+
+    msg = DummyMessage("/admin", user_id=321)
+    state = DummyState()
+    asyncio.run(plugin.cmd_admin_menu(msg, state))
+
+    assert "У вас нет доступа к меню администратора." in msg.responses


### PR DESCRIPTION
## Summary
- ensure non-admin users are denied access to admin menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690f4edf08832aae7eeb225a66812d