### PR TITLE
Add debug logs and configurable logging

### DIFF
--- a/core/db_manager.py
+++ b/core/db_manager.py
@@ -10,7 +10,10 @@ from dotenv import load_dotenv
 load_dotenv()
 DATABASE = os.getenv("DATABASE", "database.db")
 
-logging.basicConfig(level=logging.INFO)
+ENABLE_LOGGING = os.getenv("ENABLE_LOGGING", "True").lower() == "true"
+LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO").upper()
+level = getattr(logging, LOGGING_LEVEL, logging.INFO) if ENABLE_LOGGING else logging.WARNING
+logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 def initialize_db():

--- a/main.py
+++ b/main.py
@@ -45,8 +45,13 @@ if not ADMIN_IDS:
         "ADMIN_IDS не задан – команда /admin будет недоступна"
     )
 
-logging.basicConfig(level=logging.INFO)
+# Настройка логирования
+ENABLE_LOGGING = os.getenv("ENABLE_LOGGING", "True").lower() == "true"
+LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO").upper()
+level = getattr(logging, LOGGING_LEVEL, logging.INFO) if ENABLE_LOGGING else logging.WARNING
+logging.basicConfig(level=level, force=True)
 logger = logging.getLogger(__name__)
+logger.debug(f"ADMIN_IDS parsed: {ADMIN_IDS}")
 
 async def main():
     # Инициализация БД

--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -35,6 +35,7 @@ class AdminMenuPlugin:
         # Загружаем admin_ids из переменной окружения с помощью regex
         ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
         self.admin_ids = [int(x) for x in ids]
+        logger.debug(f"Parsed admin_ids: {self.admin_ids}")
         # Экземпляры вспомогательных плагинов
         from plugins.survey_plugin import SurveyPlugin
         from plugins.export_plugin import ExportPlugin

--- a/plugins/admin_plugin.py
+++ b/plugins/admin_plugin.py
@@ -14,8 +14,8 @@ from dotenv import load_dotenv
 load_dotenv()
 ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
 ADMIN_IDS = [int(x) for x in ids]
-
 logger = logging.getLogger(__name__)
+logger.debug(f"Parsed ADMIN_IDS: {ADMIN_IDS}")
 
 # Оборачиваем административные функции в плагин
 


### PR DESCRIPTION
## Summary
- log parsed admin IDs during startup and plugin initialization
- log parsed admin IDs in admin menu plugin
- configure logging based on `ENABLE_LOGGING` and `LOGGING_LEVEL`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691c97362c832ab80c516c7382e730