### PR TITLE
Add debug logs to command handlers

### DIFF
--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -144,6 +144,7 @@ class AdminMenuPlugin:
     
     async def cmd_admin_menu(self, message: types.Message, state: FSMContext):
         """Обрабатывает команду /admin"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         if message.from_user.id not in self.admin_ids:
             await message.answer("У вас нет доступа к меню администратора.")
             return

--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -170,6 +170,7 @@ class EditQuestionPlugin:
     
     async def cmd_edit_question(self, message: types.Message, state: FSMContext):
         """Обрабатывает команду /edit_question"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         user_id = message.from_user.id
         
         # Получаем опросы, созданные этим администратором

--- a/plugins/export_plugin.py
+++ b/plugins/export_plugin.py
@@ -51,6 +51,7 @@ class ExportPlugin:
         return [types.BotCommand(command="export", description="Экспорт данных опросов")]
 
     async def cmd_export(self, message: types.Message):
+        logger.debug(f"{message.text} from {message.from_user.id}")
         user_id = message.from_user.id
         all_surveys = storage.get_all_surveys()
         if not all_surveys:

--- a/plugins/roles_plugin.py
+++ b/plugins/roles_plugin.py
@@ -171,6 +171,7 @@ class RolesPlugin:
     
     async def cmd_roles(self, message: types.Message):
         """Обрабатывает команду /roles"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         builder = InlineKeyboardBuilder()
         builder.button(text="👤 Назначить роль пользователю", callback_data="roles_assign")
         builder.button(text="✏️ Редактировать роли", callback_data="roles_edit")

--- a/plugins/scheduler_plugin.py
+++ b/plugins/scheduler_plugin.py
@@ -115,6 +115,7 @@ class SchedulerPlugin:
 
     async def cmd_schedule(self, message: types.Message, state: FSMContext):
         """Обработка команды /schedule — начать процесс планирования опроса"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
 
         user_id = message.from_user.id
         all_surveys = storage.get_all_surveys()
@@ -476,6 +477,7 @@ class SchedulerPlugin:
 
     async def cmd_list_scheduled(self, message: types.Message):
         """Обработка команды /scheduled — список запланированных опросов для данного пользователя"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         user_id = message.from_user.id
         scheduled_surveys = storage.get_setting('scheduled_surveys', [])
 

--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -167,6 +167,7 @@ class SurveyPlugin:
 
     async def cmd_create_survey(self, message: types.Message, state: FSMContext):
         """Обработчик команды создания нового опроса"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         await state.set_state(SurveyStates.TITLE)
         await state.update_data(creator_id=message.from_user.id, questions=[])
         await message.answer("Введите название опроса:")
@@ -465,6 +466,7 @@ class SurveyPlugin:
 
     async def cmd_finish_questions(self, message: types.Message, state: FSMContext):
         """Завершает ввод вопросов и переходит к указанию срока"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         data = await state.get_data()
         if not data.get('questions'):
             await message.answer("Вы не добавили ни одного вопроса.")
@@ -475,12 +477,14 @@ class SurveyPlugin:
 
     async def cmd_questions_count(self, message: types.Message, state: FSMContext):
         """Отображает количество уже добавленных вопросов"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         data = await state.get_data()
         count = len(data.get('questions', []))
         await message.answer(f"Количество добавленных вопросов: {count}")
 
     async def cmd_view_surveys(self, message: types.Message, state: FSMContext):
         """Обработчик команды просмотра опросов"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         user_id = message.from_user.id
         surveys = storage.get_all_surveys()
         user_surveys = {k: v for k, v in surveys.items() if v.get('creator_id') == user_id}

--- a/plugins/survey_templates_plugin.py
+++ b/plugins/survey_templates_plugin.py
@@ -64,6 +64,7 @@ class SurveyTemplatesPlugin:
         return storage.data.setdefault("templates", {})
 
     async def cmd_save_template(self, message: types.Message):
+        logger.debug(f"{message.text} from {message.from_user.id}")
         parts = message.text.split(maxsplit=2)
         if len(parts) < 3:
             await message.answer(
@@ -88,6 +89,7 @@ class SurveyTemplatesPlugin:
         await message.answer(f"Шаблон '{name}' сохранён")
 
     async def cmd_list_templates(self, message: types.Message):
+        logger.debug(f"{message.text} from {message.from_user.id}")
         templates = self._get_templates()
         if not templates:
             await message.answer("Шаблоны отсутствуют")
@@ -96,6 +98,7 @@ class SurveyTemplatesPlugin:
         await message.answer(text)
 
     async def cmd_delete_template(self, message: types.Message):
+        logger.debug(f"{message.text} from {message.from_user.id}")
         parts = message.text.split(maxsplit=1)
         if len(parts) < 2:
             await message.answer("Использование: /delete_template <template_name>")
@@ -110,6 +113,7 @@ class SurveyTemplatesPlugin:
             await message.answer("Шаблон не найден")
 
     async def cmd_use_template(self, message: types.Message):
+        logger.debug(f"{message.text} from {message.from_user.id}")
         parts = message.text.split(maxsplit=2)
         if len(parts) < 3:
             await message.answer(

--- a/plugins/test_mode_plugin.py
+++ b/plugins/test_mode_plugin.py
@@ -41,6 +41,7 @@ class TestModePlugin:
         return [types.BotCommand(command="test_mode", description="Тестовый режим для опросов")]
 
     async def cmd_test_mode(self, message: types.Message, state: FSMContext):
+        logger.debug(f"{message.text} from {message.from_user.id}")
         user_id = message.from_user.id
         # Получаем все опросы пользователя
         all_surveys = storage.get_all_surveys()

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -122,6 +122,7 @@ class ViewSurveysPlugin:
     
     async def cmd_view_surveys(self, message: types.Message, state: FSMContext):
         """Обрабатывает команду /view_surveys"""
+        logger.debug(f"{message.text} from {message.from_user.id}")
         user_id = message.from_user.id
         surveys = await get_surveys(user_id=user_id)
         


### PR DESCRIPTION
## Summary
- log user commands in every cmd handler across plugins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869238d3ed8832a8f3db005bd84e4e3