### PR TITLE
Add centralized logging helper

### DIFF
--- a/core/db_manager.py
+++ b/core/db_manager.py
@@ -9,11 +9,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 DATABASE = os.getenv("DATABASE", "database.db")
-
-ENABLE_LOGGING = os.getenv("ENABLE_LOGGING", "True").lower() == "true"
-LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO").upper()
-level = getattr(logging, LOGGING_LEVEL, logging.INFO) if ENABLE_LOGGING else logging.WARNING
-logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 def initialize_db():

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from aiogram import Dispatcher
-from dotenv import load_dotenv
+from utils.logging_utils import configure_logging
 
 # Здесь пытаемся импортировать DefaultBotProperties, если его нет – игнорируем
 try:
@@ -20,7 +20,7 @@ except ImportError:
 from core.db_manager import initialize_db
 from plugin_manager import PluginManager
 
-load_dotenv()
+configure_logging()
 
 from aiogram import __version__ as aiogram_version
 from packaging.version import parse as parse_version
@@ -45,11 +45,7 @@ if not ADMIN_IDS:
         "ADMIN_IDS не задан – команда /admin будет недоступна"
     )
 
-# Настройка логирования
-ENABLE_LOGGING = os.getenv("ENABLE_LOGGING", "True").lower() == "true"
-LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO").upper()
-level = getattr(logging, LOGGING_LEVEL, logging.INFO) if ENABLE_LOGGING else logging.WARNING
-logging.basicConfig(level=level, force=True)
+# Логгер приложения
 logger = logging.getLogger(__name__)
 logger.debug(f"ADMIN_IDS parsed: {ADMIN_IDS}")
 

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,0 +1,12 @@
+import logging
+import os
+from dotenv import load_dotenv
+
+
+def configure_logging():
+    """Load env vars and configure logging level."""
+    load_dotenv()
+    level_name = os.getenv("LOGGING_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(level=level, force=True)
+


### PR DESCRIPTION
## Summary
- implement a `configure_logging` helper in `utils`
- initialize logging in `main.py`
- drop duplicate logger setup from `core/db_manager.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686925f8cb48832a89170c9632d01f59