### PR TITLE
Fix polling with allowed updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,8 +72,10 @@ async def main():
 
     logger.info("Бот запущен и ожидает обновлений...")
 
+    allowed_updates = dp.resolve_used_update_types()
+
     try:
-        await dp.start_polling(bot)
+        await dp.start_polling(bot, allowed_updates=allowed_updates)
     finally:
         await bot.session.close()
 


### PR DESCRIPTION
## Summary
- call `Dispatcher.resolve_used_update_types()` and pass it to `start_polling`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686929136bb4832a96c55ad89978b7f0