### PR TITLE
Fix missing re import

### DIFF
--- a/handlers/admin_handlers.py
+++ b/handlers/admin_handlers.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 from dotenv import load_dotenv
 
 from aiogram import Router, Bot, Dispatcher, F


### PR DESCRIPTION
## Summary
- import `re` in `admin_handlers`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a74fdc9a0832a8f291aef3adf5de0