### PR TITLE
Add env utility for admin ids

### DIFF
--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -5,9 +5,8 @@
 """
 
 import logging
-import os
-import re
 from dotenv import load_dotenv
+from utils.env_utils import parse_admin_ids
 from aiogram import Dispatcher, types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.fsm.context import FSMContext
@@ -32,9 +31,8 @@ class AdminMenuPlugin:
     def __init__(self):
         self.name = "admin_menu_plugin"
         self.description = "Функциональность административного меню"
-        # Загружаем admin_ids из переменной окружения с помощью regex
-        ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
-        self.admin_ids = [int(x) for x in ids]
+        # Загружаем admin_ids из переменной окружения
+        self.admin_ids = parse_admin_ids()
         logger.debug(f"Parsed admin_ids: {self.admin_ids}")
         # Экземпляры вспомогательных плагинов
         from plugins.survey_plugin import SurveyPlugin

--- a/plugins/admin_plugin.py
+++ b/plugins/admin_plugin.py
@@ -7,13 +7,11 @@ Admin Plugin для Telegram бота.
 import logging
 from aiogram.client.bot import Bot
 from core.db_manager import get_all_groups, get_poll_by_id
-import os
-import re
 from dotenv import load_dotenv
+from utils.env_utils import parse_admin_ids
 
 load_dotenv()
-ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
-ADMIN_IDS = [int(x) for x in ids]
+ADMIN_IDS = parse_admin_ids()
 logger = logging.getLogger(__name__)
 logger.debug(f"Parsed ADMIN_IDS: {ADMIN_IDS}")
 

--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -20,14 +20,12 @@ from core.db_manager import (
     get_questions_by_poll,
 )
 import sqlite3
-import os
-import re
 from dotenv import load_dotenv
+from utils.env_utils import parse_admin_ids
 from typing import List, Dict, Optional
 
 load_dotenv()
-ids = re.findall(r"\d+", os.getenv("ADMIN_IDS", ""))
-ADMIN_IDS = [int(x) for x in ids]
+ADMIN_IDS = parse_admin_ids()
 
 
 def is_admin(user_id: int) -> bool:

--- a/utils/env_utils.py
+++ b/utils/env_utils.py
@@ -1,0 +1,8 @@
+import os
+import re
+
+
+def parse_admin_ids() -> list[int]:
+    """Parse ADMIN_IDS from environment and return a list of ints."""
+    ids = re.findall(r"\d+", os.environ.get("ADMIN_IDS", ""))
+    return [int(x) for x in ids]


### PR DESCRIPTION
## Summary
- centralize admin ID parsing in `utils/env_utils.parse_admin_ids`
- use the helper in admin-related plugins

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7e9057d4832a88cd435eece24193