### PR TITLE
Add shared ResponseMixin for plugins

### DIFF
--- a/plugins/multiple_choice_plugin.py
+++ b/plugins/multiple_choice_plugin.py
@@ -11,6 +11,7 @@ from aiogram import Dispatcher
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import CallbackQuery, Message
 from core.db_manager import add_response
+from plugins.response_mixin import ResponseMixin
 
 # Поправленные импорты для хранилища
 try:
@@ -26,7 +27,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-class MultipleChoicePlugin:
+class MultipleChoicePlugin(ResponseMixin):
     """Плагин для вопросов с множественным выбором"""
 
     def __init__(self):
@@ -232,22 +233,6 @@ class MultipleChoicePlugin:
         storage.set_user_state(user_id, key, None)
         await message.answer("✅ Ваш ответ записан!")
 
-    def _add_or_update_response(self, survey, user_id, question_id, new_response):
-        """Добавляет или обновляет ответ в опросе"""
-        # Для анонимных опросов всегда добавляем новый ответ
-        if survey.get('is_anonymous'):
-            survey['responses'].append(new_response)
-            return
-
-        # Для неанонимных опросов обновляем существующий ответ, если есть
-        for i, response in enumerate(survey['responses']):
-            if (response.get('user_id') == user_id and
-                response.get('question_id') == question_id):
-                survey['responses'][i] = new_response
-                return
-
-        # Если ответа ещё нет, добавляем новый
-        survey['responses'].append(new_response)
 
     def process_results(self, question, responses):
         """Обрабатывает результаты для этого типа вопроса"""

--- a/plugins/response_mixin.py
+++ b/plugins/response_mixin.py
@@ -1,0 +1,11 @@
+class ResponseMixin:
+    def _add_or_update_response(self, survey, user_id, question_id, new_response):
+        """Add or update a response in the survey."""
+        if survey.get('is_anonymous'):
+            survey['responses'].append(new_response)
+            return
+        for i, response in enumerate(survey['responses']):
+            if response.get('user_id') == user_id and response.get('question_id') == question_id:
+                survey['responses'][i] = new_response
+                return
+        survey['responses'].append(new_response)

--- a/plugins/single_choice_plugin.py
+++ b/plugins/single_choice_plugin.py
@@ -5,6 +5,7 @@
 from aiogram import Dispatcher, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from core.db_manager import add_response
+from plugins.response_mixin import ResponseMixin
 import logging
 
 try:
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 OTHER_OPTION = "Другое…"
 
-class SingleChoicePlugin:
+class SingleChoicePlugin(ResponseMixin):
     def __init__(self):
         self.name = "single_choice_plugin"
         self.description = "Тип вопроса - одиночный выбор"
@@ -119,15 +120,6 @@ class SingleChoicePlugin:
         storage.save_survey(survey_id, survey)
         storage.set_user_state(user_id, 'single_other', None)
         await message.answer("✅ Ваш ответ записан!")
-    def _add_or_update_response(self, survey, user_id, question_id, new_response):
-        if survey['is_anonymous']:
-            survey['responses'].append(new_response)
-            return
-        for i, response in enumerate(survey['responses']):
-            if response.get('user_id') == user_id and response.get('question_id') == question_id:
-                survey['responses'][i] = new_response
-                return
-        survey['responses'].append(new_response)
     def on_plugin_load(self):
         logger.info("Плагин одиночного выбора загружен")
     def on_plugin_unload(self):

--- a/plugins/text_answer_plugin.py
+++ b/plugins/text_answer_plugin.py
@@ -12,6 +12,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import StateFilter  # Добавляем фильтр состояния
 import logging
 from core.db_manager import add_response
+from plugins.response_mixin import ResponseMixin
 
 # Импорт хранилища из storage_plugin
 try:
@@ -29,7 +30,7 @@ class TextAnswerStates(StatesGroup):
     """Состояния обработки текстового ответа"""
     WAITING_FOR_ANSWER = State()
 
-class TextAnswerPlugin:
+class TextAnswerPlugin(ResponseMixin):
     """Плагин для вопросов с текстовым ответом"""
     
     def __init__(self):
@@ -141,22 +142,6 @@ class TextAnswerPlugin:
         await message.reply("✅ Ваш ответ записан! Спасибо за участие.")
         await state.clear()
     
-    def _add_or_update_response(self, survey, user_id, question_id, new_response):
-        """Добавляет или обновляет ответ в опросе"""
-        # Для анонимных опросов всегда добавляем новый ответ
-        if survey['is_anonymous']:
-            survey['responses'].append(new_response)
-            return
-        
-        # Для неанонимных опросов обновляем имеющийся ответ, если он есть
-        for i, response in enumerate(survey['responses']):
-            if (response.get('user_id') == user_id and 
-                response.get('question_id') == question_id):
-                survey['responses'][i] = new_response
-                return
-        
-        # Если ответа нет, добавляем новый
-        survey['responses'].append(new_response)
     
     def process_results(self, question, responses):
         """Обрабатывает результаты для этого типа вопроса"""


### PR DESCRIPTION
## Summary
- centralize `_add_or_update_response` logic in `ResponseMixin`
- inherit from `ResponseMixin` in single-, multiple-choice and text-answer plugins
- remove duplicated code from plugins

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7fc78dd4832a802935fef11fb35c