### PR TITLE
Fix undefined logger in survey templates plugin

### DIFF
--- a/plugins/survey_templates_plugin.py
+++ b/plugins/survey_templates_plugin.py
@@ -9,6 +9,9 @@ from aiogram import Dispatcher, types
 from aiogram.filters import Command
 from datetime import datetime
 import uuid
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Используем хранилище из storage_plugin
 try:


### PR DESCRIPTION
## Summary
- import `logging` in survey templates plugin
- define module `logger`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aae1458fc832a8796e147a7058d87