### PR TITLE
Load plugins in stable order

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -32,7 +32,7 @@ class PluginManager:
             os.makedirs(self.plugin_dir)
             return
             
-        for filename in os.listdir(self.plugin_dir):
+        for filename in sorted(os.listdir(self.plugin_dir)):
             if filename.endswith("_plugin.py") and not filename.startswith("__"):
                 logger.debug(f"Loading plugin file: {filename}")
                 plugin_name = filename[:-3]  # убираем расширение .py


### PR DESCRIPTION
## Summary
- ensure plugin filenames are processed in sorted order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac07720b0832abd3e9b5c7e52a0af