### PR TITLE
Fix schedule handlers

### DIFF
--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -110,6 +110,14 @@ class SurveyPlugin:
             StateFilter(SurveyStates.SCHEDULING)
         )
         dp.message.register(
+            self.process_schedule_date,
+            StateFilter(SurveyStates.SCHEDULE_DATE)
+        )
+        dp.message.register(
+            self.process_schedule_time,
+            StateFilter(SurveyStates.SCHEDULE_TIME)
+        )
+        dp.message.register(
             self.process_confirmation,
             StateFilter(SurveyStates.CONFIRMATION)
         )


### PR DESCRIPTION
## Summary
- register `process_schedule_date` and `process_schedule_time` in `SurveyPlugin.register_handlers`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac506654c832a8627d9f7341a4699