### PR TITLE
Refactor AdminMenu plugin to use PluginManager

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -18,46 +18,59 @@ logger = logging.getLogger(__name__)
 
 class PluginManager:
     """Управляет всеми плагинами бота"""
-    
+
     def __init__(self, dp: Dispatcher, bot: Bot):
         self.dp = dp
         self.bot = bot
         self.plugins = {}
         self.plugin_dir = "plugins"
-        
+
     async def load_plugins(self):
         """Загружает все плагины из каталога plugins"""
         if not os.path.exists(self.plugin_dir):
             logger.warning(f"Каталог плагинов {self.plugin_dir} не найден")
             os.makedirs(self.plugin_dir)
             return
-            
-        for filename in sorted(os.listdir(self.plugin_dir)):
-            if filename.endswith("_plugin.py") and not filename.startswith("__"):
-                logger.debug(f"Loading plugin file: {filename}")
-                plugin_name = filename[:-3]  # убираем расширение .py
-                await self.load_plugin(plugin_name)
-                
+
+        plugin_files = [
+            f
+            for f in sorted(os.listdir(self.plugin_dir))
+            if f.endswith("_plugin.py") and not f.startswith("__")
+        ]
+
+        # Загружаем admin_menu_plugin последним, т.к. он зависит от других
+        if "admin_menu_plugin.py" in plugin_files:
+            plugin_files.remove("admin_menu_plugin.py")
+            plugin_files.append("admin_menu_plugin.py")
+
+        for filename in plugin_files:
+            logger.debug(f"Loading plugin file: {filename}")
+            plugin_name = filename[:-3]  # убираем расширение .py
+            await self.load_plugin(plugin_name)
+
     async def load_plugin(self, plugin_name: str) -> bool:
         """Загружает конкретный плагин по имени"""
         if plugin_name in self.plugins:
             logger.warning(f"Плагин {plugin_name} уже загружен")
             return False
-            
+
         try:
             module = importlib.import_module(f"{self.plugin_dir}.{plugin_name}")
-            if 'bot' in inspect.signature(module.load_plugin).parameters:
-                plugin = module.load_plugin(self.bot)
-            else:
-                plugin = module.load_plugin()
-            
+            sig = inspect.signature(module.load_plugin)
+            kwargs = {}
+            if "bot" in sig.parameters:
+                kwargs["bot"] = self.bot
+            if "plugin_manager" in sig.parameters:
+                kwargs["plugin_manager"] = self
+            plugin = module.load_plugin(**kwargs)
+
             # Регистрируем обработчики плагина
             await plugin.register_handlers(self.dp)
-            
+
             # Вызываем хук загрузки, если он определён
             if hasattr(plugin, "on_plugin_load"):
                 plugin.on_plugin_load()
-                
+
             self.plugins[plugin_name] = plugin
             logger.info(f"Плагин {plugin_name} успешно загружен")
             logger.debug(f"Plugin {plugin_name} imported successfully")
@@ -66,38 +79,38 @@ class PluginManager:
         except Exception as e:
             logger.exception(f"Не удалось загрузить плагин {plugin_name}: {e}")
             return False
-            
+
     async def unload_plugin(self, plugin_name: str) -> bool:
         """Выгружает конкретный плагин по имени"""
         if plugin_name not in self.plugins:
             logger.warning(f"Плагин {plugin_name} не загружен")
             return False
-            
+
         try:
             plugin = self.plugins[plugin_name]
-            
+
             # Вызываем хук выгрузки, если он определён
             if hasattr(plugin, "on_plugin_unload"):
                 plugin.on_plugin_unload()
-                
+
             # Убираем плагин из реестра
             del self.plugins[plugin_name]
-            
+
             logger.info(f"Плагин {plugin_name} успешно выгружен")
             return True
-            
+
         except Exception as e:
             logger.error(f"Не удалось выгрузить плагин {plugin_name}: {e}")
             return False
-            
+
     def get_plugin(self, plugin_name: str) -> Optional[Any]:
         """Возвращает плагин по имени"""
         return self.plugins.get(plugin_name)
-        
+
     def get_all_plugins(self) -> Dict[str, Any]:
         """Возвращает все загруженные плагины"""
         return self.plugins
-        
+
     def get_all_commands(self) -> List[BotCommand]:
         """Получает команды из всех плагинов"""
         commands = []
@@ -105,14 +118,14 @@ class PluginManager:
             if hasattr(plugin, "get_commands"):
                 commands.extend(plugin.get_commands())
         return commands
-    
+
     async def setup_bot_commands(self, bot: Bot):
         """Настраивает команды бота на основе плагинов"""
         commands = self.get_all_commands()
         if commands:
             await bot.set_my_commands(commands)
             logger.info(f"Установлено команд: {len(commands)}")
-    
+
     def get_all_keyboards(self) -> Dict[str, Any]:
         """Получает все клавиатуры из плагинов"""
         keyboards = {}

--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -7,6 +7,9 @@
 import logging
 from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
+from typing import Optional
+
+from plugin_manager import PluginManager
 from aiogram import Dispatcher, types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.fsm.context import FSMContext
@@ -18,54 +21,68 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+
 class AdminMenuStates(StatesGroup):
     """Состояния для административного меню"""
-    MAIN_MENU = State()         # Главное меню
-    SURVEYS_MENU = State()      # Меню опросов
-    ANALYTICS_MENU = State()    # Меню аналитики
-    SETTINGS_MENU = State()     # Меню настроек
+
+    MAIN_MENU = State()  # Главное меню
+    SURVEYS_MENU = State()  # Меню опросов
+    ANALYTICS_MENU = State()  # Меню аналитики
+    SETTINGS_MENU = State()  # Меню настроек
+
 
 class AdminMenuPlugin:
     """Плагин административного меню"""
-    
-    def __init__(self):
+
+    def __init__(self, plugin_manager: Optional[PluginManager] = None):
         self.name = "admin_menu_plugin"
         self.description = "Функциональность административного меню"
         # Загружаем admin_ids из переменной окружения
         self.admin_ids = parse_admin_ids()
         logger.debug(f"Parsed admin_ids: {self.admin_ids}")
-        # Экземпляры вспомогательных плагинов
-        from plugins.survey_plugin import SurveyPlugin
-        from plugins.export_plugin import ExportPlugin
-        from plugins.test_mode_plugin import TestModePlugin
-        from plugins.survey_templates_plugin import SurveyTemplatesPlugin
-        from plugins.roles_plugin import RolesPlugin
+        self.plugin_manager = plugin_manager
 
-        self.survey_plugin = SurveyPlugin()
-        self.export_plugin = ExportPlugin()
-        self.test_mode_plugin = TestModePlugin()
-        self.templates_plugin = SurveyTemplatesPlugin()
-        self.roles_plugin = RolesPlugin()
-    
+        if plugin_manager:
+            self.survey_plugin = plugin_manager.get_plugin("survey_plugin")
+            self.export_plugin = plugin_manager.get_plugin("export_plugin")
+            self.test_mode_plugin = plugin_manager.get_plugin("test_mode_plugin")
+            self.templates_plugin = plugin_manager.get_plugin("survey_templates_plugin")
+            self.roles_plugin = plugin_manager.get_plugin("roles_plugin")
+        else:
+            # Fallback для тестов или изолированного использования
+            from plugins.survey_plugin import SurveyPlugin
+            from plugins.export_plugin import ExportPlugin
+            from plugins.test_mode_plugin import TestModePlugin
+            from plugins.survey_templates_plugin import SurveyTemplatesPlugin
+            from plugins.roles_plugin import RolesPlugin
+
+            self.survey_plugin = SurveyPlugin()
+            self.export_plugin = ExportPlugin()
+            self.test_mode_plugin = TestModePlugin()
+            self.templates_plugin = SurveyTemplatesPlugin()
+            self.roles_plugin = RolesPlugin()
+
     async def register_handlers(self, dp: Dispatcher):
         """Регистрирует все обработчики для плагина"""
-        dp.message.register(
-            self.cmd_admin_menu,
-            Command(commands=["admin"])
-        )
+        dp.message.register(self.cmd_admin_menu, Command(commands=["admin"]))
         dp.message.register(
             self.handle_main_menu,
             lambda msg: msg.text in ["📊 Опросы", "📈 Аналитика", "⚙ Настройки"],
-            StateFilter(AdminMenuStates.MAIN_MENU)
+            StateFilter(AdminMenuStates.MAIN_MENU),
         )
         dp.message.register(
             self.handle_back,
             lambda msg: msg.text == "🔙 Назад",
-            StateFilter(AdminMenuStates.SURVEYS_MENU, AdminMenuStates.ANALYTICS_MENU, AdminMenuStates.SETTINGS_MENU)
+            StateFilter(
+                AdminMenuStates.SURVEYS_MENU,
+                AdminMenuStates.ANALYTICS_MENU,
+                AdminMenuStates.SETTINGS_MENU,
+            ),
         )
         dp.message.register(
             self.handle_surveys_menu,
-            lambda msg: msg.text in [
+            lambda msg: msg.text
+            in [
                 "Создать опрос",
                 "Мои опросы",
                 "Шаблоны вопросов",
@@ -75,7 +92,8 @@ class AdminMenuPlugin:
         )
         dp.message.register(
             self.handle_analytics_menu,
-            lambda msg: msg.text in [
+            lambda msg: msg.text
+            in [
                 "Статистика опросов",
                 "Экспорт данных",
                 "Активность группы",
@@ -85,7 +103,8 @@ class AdminMenuPlugin:
         )
         dp.message.register(
             self.handle_settings_menu,
-            lambda msg: msg.text in [
+            lambda msg: msg.text
+            in [
                 "Общие настройки",
                 "Настройки уведомлений",
                 "Управление доступом",
@@ -93,28 +112,28 @@ class AdminMenuPlugin:
             ],
             StateFilter(AdminMenuStates.SETTINGS_MENU),
         )
-    
+
     def get_commands(self):
         """Возвращает список команд, предоставляемых плагином"""
         return [
             types.BotCommand(command="admin", description="Открыть меню администратора")
         ]
-    
+
     def get_keyboards(self):
         """Возвращает словарь клавиатур для различных меню"""
         return {
-            'admin_main': ReplyKeyboardMarkup(
+            "admin_main": ReplyKeyboardMarkup(
                 keyboard=[
                     [
                         KeyboardButton(text="📊 Опросы"),
                         KeyboardButton(text="📈 Аналитика"),
                     ],
-                    [KeyboardButton(text="⚙ Настройки")]
+                    [KeyboardButton(text="⚙ Настройки")],
                 ],
                 resize_keyboard=True,
-                one_time_keyboard=False
+                one_time_keyboard=False,
             ),
-            'admin_surveys': ReplyKeyboardMarkup(
+            "admin_surveys": ReplyKeyboardMarkup(
                 keyboard=[
                     [
                         KeyboardButton(text="Создать опрос"),
@@ -124,12 +143,12 @@ class AdminMenuPlugin:
                         KeyboardButton(text="Шаблоны вопросов"),
                         KeyboardButton(text="Настройки опросов"),
                     ],
-                    [KeyboardButton(text="🔙 Назад")]
+                    [KeyboardButton(text="🔙 Назад")],
                 ],
                 resize_keyboard=True,
-                one_time_keyboard=False
+                one_time_keyboard=False,
             ),
-            'admin_analytics': ReplyKeyboardMarkup(
+            "admin_analytics": ReplyKeyboardMarkup(
                 keyboard=[
                     [
                         KeyboardButton(text="Статистика опросов"),
@@ -139,12 +158,12 @@ class AdminMenuPlugin:
                         KeyboardButton(text="Активность группы"),
                         KeyboardButton(text="Рейтинги"),
                     ],
-                    [KeyboardButton(text="🔙 Назад")]
+                    [KeyboardButton(text="🔙 Назад")],
                 ],
                 resize_keyboard=True,
-                one_time_keyboard=False
+                one_time_keyboard=False,
             ),
-            'admin_settings': ReplyKeyboardMarkup(
+            "admin_settings": ReplyKeyboardMarkup(
                 keyboard=[
                     [
                         KeyboardButton(text="Общие настройки"),
@@ -154,13 +173,13 @@ class AdminMenuPlugin:
                         KeyboardButton(text="Управление доступом"),
                         KeyboardButton(text="Тестовый режим"),
                     ],
-                    [KeyboardButton(text="🔙 Назад")]
+                    [KeyboardButton(text="🔙 Назад")],
                 ],
                 resize_keyboard=True,
-                one_time_keyboard=False
-            )
+                one_time_keyboard=False,
+            ),
         }
-    
+
     async def cmd_admin_menu(self, message: types.Message, state: FSMContext):
         """Обрабатывает команду /admin"""
         logger.debug(f"{message.text} from {message.from_user.id}")
@@ -168,19 +187,29 @@ class AdminMenuPlugin:
             await message.answer("У вас нет доступа к меню администратора.")
             return
         await state.set_state(AdminMenuStates.MAIN_MENU)
-        await message.answer("Главное меню администратора:", reply_markup=self.get_keyboards()['admin_main'])
-    
+        await message.answer(
+            "Главное меню администратора:",
+            reply_markup=self.get_keyboards()["admin_main"],
+        )
+
     async def handle_main_menu(self, message: types.Message, state: FSMContext):
         """Обрабатывает выбор пункта главного меню"""
         if message.text == "📊 Опросы":
             await state.set_state(AdminMenuStates.SURVEYS_MENU)
-            await message.answer("Меню управления опросами:", reply_markup=self.get_keyboards()['admin_surveys'])
+            await message.answer(
+                "Меню управления опросами:",
+                reply_markup=self.get_keyboards()["admin_surveys"],
+            )
         elif message.text == "📈 Аналитика":
             await state.set_state(AdminMenuStates.ANALYTICS_MENU)
-            await message.answer("Меню аналитики:", reply_markup=self.get_keyboards()['admin_analytics'])
+            await message.answer(
+                "Меню аналитики:", reply_markup=self.get_keyboards()["admin_analytics"]
+            )
         elif message.text == "⚙ Настройки":
             await state.set_state(AdminMenuStates.SETTINGS_MENU)
-            await message.answer("Меню настроек:", reply_markup=self.get_keyboards()['admin_settings'])
+            await message.answer(
+                "Меню настроек:", reply_markup=self.get_keyboards()["admin_settings"]
+            )
 
     async def handle_surveys_menu(self, message: types.Message, state: FSMContext):
         """Выбор пунктов в меню опросов"""
@@ -212,12 +241,16 @@ class AdminMenuPlugin:
             await self.roles_plugin.cmd_roles(message, state)
         else:
             await message.answer("Функция в разработке")
-    
+
     async def handle_back(self, message: types.Message, state: FSMContext):
         """Обрабатывает кнопку 'Назад'"""
         await state.set_state(AdminMenuStates.MAIN_MENU)
-        await message.answer("Главное меню администратора:", reply_markup=self.get_keyboards()['admin_main'])
+        await message.answer(
+            "Главное меню администратора:",
+            reply_markup=self.get_keyboards()["admin_main"],
+        )
 
-def load_plugin():
+
+def load_plugin(plugin_manager: Optional[PluginManager] = None):
     """Загружает плагин"""
-    return AdminMenuPlugin()
+    return AdminMenuPlugin(plugin_manager=plugin_manager)


### PR DESCRIPTION
## Summary
- ensure PluginManager loads admin menu plugin last and pass PluginManager when plugins request it
- make `load_plugin` helper detect `plugin_manager` argument
- update AdminMenu plugin to obtain dependencies via PluginManager when provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ae140e3c8832a91c551bfbdf01dc1