### PR TITLE
Refactor admin menu plugin manager requirement

### DIFF
--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -7,7 +7,7 @@
 import logging
 from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
-from typing import Optional
+
 
 from plugin_manager import PluginManager
 from aiogram import Dispatcher, types
@@ -41,7 +41,7 @@ class AdminMenuStates(StatesGroup):
 class AdminMenuPlugin:
     """Плагин административного меню"""
 
-    def __init__(self, plugin_manager: Optional[PluginManager] = None):
+    def __init__(self, plugin_manager: PluginManager):
         self.name = "admin_menu_plugin"
         self.description = "Функциональность административного меню"
         # Загружаем admin_ids из переменной окружения
@@ -60,9 +60,7 @@ class AdminMenuPlugin:
 
     def _get_or_create(self, plugin_name: str, cls):
         """Fetches a plugin from PluginManager or raises if missing."""
-        plugin = None
-        if self.plugin_manager:
-            plugin = self.plugin_manager.get_plugin(plugin_name)
+        plugin = self.plugin_manager.get_plugin(plugin_name)
         if plugin:
             return plugin
         logger.error(
@@ -132,66 +130,6 @@ class AdminMenuPlugin:
 
     def get_keyboards(self):
         """Возвращает словарь клавиатур для различных меню"""
-        if not self.plugin_manager:
-            return {
-                "admin_main": ReplyKeyboardMarkup(
-                    keyboard=[
-                        [
-                            KeyboardButton(text="📊 Опросы"),
-                            KeyboardButton(text="📈 Аналитика"),
-                        ],
-                        [KeyboardButton(text="⚙ Настройки")],
-                    ],
-                    resize_keyboard=True,
-                    one_time_keyboard=False,
-                ),
-                "admin_surveys": ReplyKeyboardMarkup(
-                    keyboard=[
-                        [
-                            KeyboardButton(text="Создать опрос"),
-                            KeyboardButton(text="Мои опросы"),
-                        ],
-                        [
-                            KeyboardButton(text="Шаблоны вопросов"),
-                            KeyboardButton(text="Настройки опросов"),
-                        ],
-                        [KeyboardButton(text="🔙 Назад")],
-                    ],
-                    resize_keyboard=True,
-                    one_time_keyboard=False,
-                ),
-                "admin_analytics": ReplyKeyboardMarkup(
-                    keyboard=[
-                        [
-                            KeyboardButton(text="Статистика опросов"),
-                            KeyboardButton(text="Экспорт данных"),
-                        ],
-                        [
-                            KeyboardButton(text="Активность группы"),
-                            KeyboardButton(text="Рейтинги"),
-                        ],
-                        [KeyboardButton(text="🔙 Назад")],
-                    ],
-                    resize_keyboard=True,
-                    one_time_keyboard=False,
-                ),
-                "admin_settings": ReplyKeyboardMarkup(
-                    keyboard=[
-                        [
-                            KeyboardButton(text="Общие настройки"),
-                            KeyboardButton(text="Настройки уведомлений"),
-                        ],
-                        [
-                            KeyboardButton(text="Управление доступом"),
-                            KeyboardButton(text="Тестовый режим"),
-                        ],
-                        [KeyboardButton(text="🔙 Назад")],
-                    ],
-                    resize_keyboard=True,
-                    one_time_keyboard=False,
-                ),
-            }
-
         plugin_commands = self.plugin_manager.get_plugin_commands()
         buttons = []
         for cmd_list in plugin_commands.values():
@@ -303,6 +241,6 @@ class AdminMenuPlugin:
         )
 
 
-def load_plugin(plugin_manager: Optional[PluginManager] = None):
+def load_plugin(plugin_manager: PluginManager):
     """Загружает плагин"""
     return AdminMenuPlugin(plugin_manager=plugin_manager)

--- a/tests/test_admin_menu_plugins.py
+++ b/tests/test_admin_menu_plugins.py
@@ -48,9 +48,6 @@ def test_admin_menu_has_plugin_commands(monkeypatch):
     monkeypatch.setattr(types, "KeyboardButton", DummyButton, raising=False)
 
     import sys
-
-    print("DEBUG before import, path0", sys.path[0])
-    print("DEBUG aiogram in modules", "aiogram" in sys.modules)
     import os
 
     root = os.path.dirname(os.path.dirname(__file__))
@@ -82,7 +79,13 @@ def test_admin_menu_has_plugin_commands(monkeypatch):
             cmd_name = getattr(cmd, "command", None)
             assert any(t == desc or t == cmd_name for t in button_texts)
 
-    import sys
+    survey_texts = []
+    for row in keyboards["admin_surveys"].keyboard:
+        for btn in row:
+            survey_texts.append(btn.text)
 
-    print("DEBUG PATH", sys.path[0])
-    print("DEBUG modules has plugin_manager?", "plugin_manager" in sys.modules)
+    for cmds in plugin_cmds.values():
+        for cmd in cmds:
+            desc = getattr(cmd, "description", None)
+            cmd_name = getattr(cmd, "command", None)
+            assert any(t == desc or t == cmd_name for t in survey_texts)


### PR DESCRIPTION
## Summary
- require a plugin manager when initializing `AdminMenuPlugin`
- drop the static keyboard fallback
- check the survey menu buttons in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c253069a8832aa45065454e4a0f65