### PR TITLE
Introduce menu router for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ flake8
 Пример использования:
 
 ```python
-from aiogram import Dispatcher
+from aiogram import Dispatcher, Router
 from plugin_manager import PluginManager
 
 # dp — экземпляр Dispatcher
-pm = PluginManager(dp)
+router = Router()
+pm = PluginManager(dp, router=router)
 await pm.load_plugins()
 await pm.setup_bot_commands(bot)
 ```

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from core.db_manager import initialize_db
 from plugin_manager import PluginManager
+from routers.menu_router import router as menu_router
 from handlers.survey_handlers import register_survey_handlers
 from handlers.group_handlers import register_group_handlers
 from handlers.view_surveys_handler import register_view_surveys_handler
@@ -65,7 +66,7 @@ async def main():
     dp = Dispatcher()
 
     # Инициализация менеджера плагинов
-    plugin_manager = PluginManager(dp, bot, plugin_dir=PLUGIN_DIR)
+    plugin_manager = PluginManager(dp, bot, plugin_dir=PLUGIN_DIR, router=menu_router)
 
     # Загружаем плагины
     await plugin_manager.load_plugins()

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -11,7 +11,7 @@ import logging
 import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
-from aiogram import Dispatcher, Bot
+from aiogram import Dispatcher, Bot, Router
 from aiogram.types import BotCommand
 
 logger = logging.getLogger(__name__)
@@ -20,9 +20,12 @@ logger = logging.getLogger(__name__)
 class PluginManager:
     """Управляет всеми плагинами бота"""
 
-    def __init__(self, dp: Dispatcher, bot: Bot, plugin_dir: str | None = None):
+    def __init__(self, dp: Dispatcher, bot: Bot, plugin_dir: str | None = None, router: Router | None = None):
         self.dp = dp
         self.bot = bot
+        self.router = router or Router()
+        if hasattr(self.dp, "include_router"):
+            self.dp.include_router(self.router)
         self.plugins = {}
         base = Path(__file__).resolve().parent
         self.plugin_dir = Path(plugin_dir) if plugin_dir else base / "plugins"
@@ -74,7 +77,7 @@ class PluginManager:
             plugin = module.load_plugin(**kwargs)
 
             # Регистрируем обработчики плагина
-            await plugin.register_handlers(self.dp)
+            await plugin.register_handlers(self.router)
 
             # Вызываем хук загрузки, если он определён
             if hasattr(plugin, "on_plugin_load"):

--- a/plugin_template.py
+++ b/plugin_template.py
@@ -23,7 +23,7 @@
 - `on_plugin_unload()` — вызывается при выгрузке плагина.
 """
 
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command
@@ -44,13 +44,13 @@ class PluginTemplate:
         self.name = "template_plugin"
         self.description = "Шаблонный плагин"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрация всех обработчиков плагина"""
-        dp.message.register(
+        router.message.register(
             self.command_handler,
             Command(commands=["template_command"]),
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_button,
             lambda c: c.data in {"btn1", "btn2"},
         )

--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -10,7 +10,7 @@ from utils.env_utils import parse_admin_ids
 
 
 from plugin_manager import PluginManager
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -71,15 +71,15 @@ class AdminMenuPlugin:
             f"Dependency '{plugin_name}' must be loaded via PluginManager"
         )
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует все обработчики для плагина"""
-        dp.message.register(self.cmd_admin_menu, Command(commands=["admin"]))
-        dp.message.register(
+        router.message.register(self.cmd_admin_menu, Command(commands=["admin"]))
+        router.message.register(
             self.handle_main_menu,
             lambda msg: msg.text in ["📊 Опросы", "📈 Аналитика", "⚙ Настройки"],
             StateFilter(AdminMenuStates.MAIN_MENU),
         )
-        dp.message.register(
+        router.message.register(
             self.handle_back,
             lambda msg: msg.text == "🔙 Назад",
             StateFilter(
@@ -88,7 +88,7 @@ class AdminMenuPlugin:
                 AdminMenuStates.SETTINGS_MENU,
             ),
         )
-        dp.message.register(
+        router.message.register(
             self.handle_surveys_menu,
             lambda msg: msg.text
             in [
@@ -99,7 +99,7 @@ class AdminMenuPlugin:
             ],
             StateFilter(AdminMenuStates.SURVEYS_MENU),
         )
-        dp.message.register(
+        router.message.register(
             self.handle_analytics_menu,
             lambda msg: msg.text
             in [
@@ -110,7 +110,7 @@ class AdminMenuPlugin:
             ],
             StateFilter(AdminMenuStates.ANALYTICS_MENU),
         )
-        dp.message.register(
+        router.message.register(
             self.handle_settings_menu,
             lambda msg: msg.text
             in [

--- a/plugins/admin_plugin.py
+++ b/plugins/admin_plugin.py
@@ -6,6 +6,7 @@ Admin Plugin для Telegram бота.
 
 import logging
 from aiogram.client.bot import Bot
+from aiogram import Router
 from core.db_manager import get_all_groups, get_poll_by_id
 from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
@@ -23,7 +24,7 @@ class AdminPlugin:
         self.name = "admin_plugin"
         self.description = "Административные функции"
 
-    async def register_handlers(self, dp):
+    async def register_handlers(self, router: Router):
         # Здесь можно зарегистрировать обработчики административных команд.
         pass
 

--- a/plugins/captcha_plugin.py
+++ b/plugins/captcha_plugin.py
@@ -11,7 +11,7 @@ import logging
 import random
 import string
 
-from aiogram import Dispatcher
+from aiogram import Dispatcher, Router
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import ChatMemberUpdated, Message, CallbackQuery, ChatPermissions
@@ -78,12 +78,12 @@ class CaptchaPlugin:
             },
         ]
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """
         Регистрируем хендлеры для aiogram 3.x
         """
         # 1) Обработка новых участников
-        dp.chat_member.register(
+        router.chat_member.register(
             self.on_new_chat_member,
             ChatMemberUpdatedFilter(
                 member_status_changed=["member", "creator", "administrator"]
@@ -91,28 +91,28 @@ class CaptchaPlugin:
         )
 
         # 2) Обработка капчи
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_captcha, lambda c: c.data.startswith("captcha_")
         )
 
         # 3) Ограничиваем пользователей в группах, если капча не пройдена
-        dp.message.register(
+        router.message.register(
             self.check_access,
             lambda msg: msg.chat.type in ["group", "supergroup"]
             and not self.is_access_granted(msg.from_user.id),
         )
 
         # 4) Запуск короткого опроса после капчи
-        dp.callback_query.register(
+        router.callback_query.register(
             self.start_primary_survey, lambda c: c.data == "start_primary_survey"
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_primary_survey_choice,
             lambda c: c.data.startswith("primary_choice_"),
         )
 
         # 5) Обработка текстового ответа в состоянии AWAITING_RESPONSE
-        dp.message.register(
+        router.message.register(
             self.process_primary_survey_text,
             StateFilter(PrimarySurveyStates.AWAITING_RESPONSE),
         )

--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -6,7 +6,7 @@
 """
 
 import logging
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command, StateFilter
@@ -108,27 +108,27 @@ class EditQuestionPlugin:
         self.name = "edit_question"
         self.description = "Редактировать вопросы в существующих опросах"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует все обработчики плагина"""
-        dp.message.register(
+        router.message.register(
             self.cmd_edit_question,
             Command("edit_question"),
             lambda msg: is_admin(msg.from_user.id),
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_survey_selection,
             lambda c: c.data.startswith("edit_survey_"),
             StateFilter(EditQuestionStates.SelectSurvey),
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_question_selection,
             lambda c: c.data.startswith("edit_question_"),
             StateFilter(EditQuestionStates.SelectQuestion),
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_edit_action,
             lambda c: c.data.startswith("edit_action_"),
             StateFilter(
@@ -139,15 +139,15 @@ class EditQuestionPlugin:
             ),
         )
 
-        dp.message.register(
+        router.message.register(
             self.process_question_text, StateFilter(EditQuestionStates.EditQuestionText)
         )
 
-        dp.message.register(
+        router.message.register(
             self.process_new_option, StateFilter(EditQuestionStates.AddOption)
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_remove_option,
             lambda c: c.data.startswith("remove_option_"),
             StateFilter(EditQuestionStates.RemoveOption),

--- a/plugins/export_plugin.py
+++ b/plugins/export_plugin.py
@@ -5,7 +5,7 @@ import io
 import datetime
 import os
 
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 # Импорт хранилища
@@ -43,15 +43,15 @@ class ExportPlugin:
         self.name = "export_plugin"
         self.description = "Экспорт данных опросов в разные форматы"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         # Используем новые методы регистрации:
         from aiogram.filters import Command  # фильтр команд из aiogram v3
 
-        dp.message.register(self.cmd_export, Command("export"))
-        dp.callback_query.register(
+        router.message.register(self.cmd_export, Command("export"))
+        router.callback_query.register(
             self.handle_survey_selection, lambda c: c.data.startswith("export_survey_")
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_format_selection, lambda c: c.data.startswith("export_format_")
         )
 

--- a/plugins/group_event_plugin.py
+++ b/plugins/group_event_plugin.py
@@ -7,6 +7,7 @@ import logging
 import asyncio
 from aiogram.types import ChatPermissions
 from aiogram.client.bot import Bot
+from aiogram import Router
 from core.db_manager import (
     is_user_pending,
     remove_user_from_pending,
@@ -131,7 +132,7 @@ class GroupEventPlugin:
         self.bot = bot
         self.cleanup_task = None
 
-    async def register_handlers(self, dp):
+    async def register_handlers(self, router: Router):
         # При необходимости здесь можно зарегистрировать обработчики событий группы.
         pass
 

--- a/plugins/multiple_choice_plugin.py
+++ b/plugins/multiple_choice_plugin.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from aiogram import Dispatcher
+from aiogram import Router
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import CallbackQuery, Message
 from core.db_manager import add_response
@@ -43,17 +43,17 @@ class MultipleChoicePlugin(ResponseMixin):
         self.name = "multiple_choice_plugin"
         self.description = "Тип вопроса - множественный выбор"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует обработчики плагина (стиль aiogram 3.x)"""
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_multiple_choice_selection,
             lambda c: c.data.startswith("multi_choice_"),
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_multiple_choice_submit,
             lambda c: c.data.startswith("multi_submit_"),
         )
-        dp.message.register(self.process_other_input)
+        router.message.register(self.process_other_input)
 
     def get_commands(self):
         """Возвращает список команд плагина"""

--- a/plugins/roles_plugin.py
+++ b/plugins/roles_plugin.py
@@ -6,7 +6,7 @@
 """
 
 import logging
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -72,41 +72,41 @@ class RolesPlugin:
         self.name = "roles_plugin"
         self.description = "Контроль доступа на основе ролей"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует все обработчики для этого плагина"""
-        dp.message.register(
+        router.message.register(
             self.cmd_roles,
             Command(commands=["roles"]),
             lambda msg: self.has_permission(msg.from_user.id, "manage_roles"),
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_roles_action, lambda c: c.data.startswith("roles_")
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_user_selection,
             lambda c: c.data.startswith("select_user_"),
             StateFilter(RoleStates.SELECTING_USER),
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_role_selection,
             lambda c: c.data.startswith("select_role_"),
             StateFilter(RoleStates.SELECTING_ROLE),
         )
 
-        dp.message.register(
+        router.message.register(
             self.process_role_name, StateFilter(RoleStates.CREATING_ROLE)
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_permission_toggle,
             lambda c: c.data.startswith("toggle_perm_"),
             StateFilter(RoleStates.EDITING_PERMISSIONS),
         )
 
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_save_permissions,
             lambda c: c.data == "save_permissions",
             StateFilter(RoleStates.EDITING_PERMISSIONS),

--- a/plugins/scheduler_plugin.py
+++ b/plugins/scheduler_plugin.py
@@ -11,7 +11,7 @@ import logging
 import re
 from core.db_manager import get_all_groups
 
-from aiogram import Dispatcher, types, Bot
+from aiogram import Router, types, Bot
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext  # <-- Вместо dispatcher.FSMContext
 from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.filters.state
@@ -62,45 +62,45 @@ class SchedulerPlugin:
         self.close_tasks = {}
         self.bot = bot
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """
         Регистрируем хендлеры (обработчики) в стиле aiogram 3.x
         """
 
         # Вместо dp.register_message_handler(...), используем dp.message.register(...)
-        dp.message.register(
+        router.message.register(
             self.cmd_schedule,
             Command(commands=["schedule"]),  # Разрешаем команду /schedule
         )
 
         # Вместо dp.register_callback_query_handler(...), используем dp.callback_query.register(...)
         # Дополнительно учитываем, что нам нужно вызывать этот хендлер в состоянии SchedulerStates.SELECTING_SURVEY
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_survey_selection,
             lambda c: c.data.startswith("schedule_survey_"),
             SchedulerStates.SELECTING_SURVEY,
         )
 
-        dp.message.register(self.process_group_input, SchedulerStates.SELECTING_GROUPS)
+        router.message.register(self.process_group_input, SchedulerStates.SELECTING_GROUPS)
 
         # Хендлер на ввод даты (состояние SELECTING_DATE)
-        dp.message.register(self.process_date_input, SchedulerStates.SELECTING_DATE)
+        router.message.register(self.process_date_input, SchedulerStates.SELECTING_DATE)
 
         # Хендлер на ввод времени (состояние SELECTING_TIME)
-        dp.message.register(self.process_time_input, SchedulerStates.SELECTING_TIME)
+        router.message.register(self.process_time_input, SchedulerStates.SELECTING_TIME)
 
         # Хендлер на подтверждение планирования (callback) в состоянии CONFIRMING
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_confirmation,
             lambda c: c.data.startswith("schedule_confirm_"),
             SchedulerStates.CONFIRMING,
         )
 
         # Команда /scheduled (без конкретного состояния)
-        dp.message.register(self.cmd_list_scheduled, Command(commands=["scheduled"]))
+        router.message.register(self.cmd_list_scheduled, Command(commands=["scheduled"]))
 
         # Хендлер на отмену запланированного (любой стейт, или без стейта)
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_cancel_scheduled,
             lambda c: c.data.startswith("cancel_scheduled_"),
         )

--- a/plugins/single_choice_plugin.py
+++ b/plugins/single_choice_plugin.py
@@ -2,7 +2,7 @@
 Плагин для одиночного выбора.
 """
 
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from core.db_manager import add_response
 from .response_mixin import ResponseMixin
@@ -31,12 +31,12 @@ class SingleChoicePlugin(ResponseMixin):
         self.name = "single_choice_plugin"
         self.description = "Тип вопроса - одиночный выбор"
 
-    async def register_handlers(self, dp: Dispatcher):
-        dp.callback_query.register(
+    async def register_handlers(self, router: Router):
+        router.callback_query.register(
             self.process_single_choice_selection,
             lambda c: c.data.startswith("single_choice_"),
         )
-        dp.message.register(self.process_other_input)
+        router.message.register(self.process_other_input)
 
     def get_commands(self):
         return []

--- a/plugins/storage_plugin.py
+++ b/plugins/storage_plugin.py
@@ -7,6 +7,7 @@ import json
 import os
 import logging
 from typing import Dict, Any, Optional
+from aiogram import Router
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,7 @@ class StoragePlugin:
         self.name = "storage_plugin"
         self.description = "Обеспечивает постоянное хранилище данных"
 
-    async def register_handlers(self, dp):
+    async def register_handlers(self, router: Router):
         """Обработчиков для этого плагина нет"""
         pass
 

--- a/plugins/survey_plugin.py
+++ b/plugins/survey_plugin.py
@@ -4,7 +4,7 @@
 """
 
 import logging
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -93,53 +93,53 @@ class SurveyPlugin:
         self.description = "Создание и управление опросами"
         self.scheduled_tasks = {}
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует все обработчики для плагина опросов"""
         # Обработчики создания опроса
-        dp.message.register(self.cmd_create_survey, Command(commands=["create_survey"]))
-        dp.message.register(
+        router.message.register(self.cmd_create_survey, Command(commands=["create_survey"]))
+        router.message.register(
             self.cmd_create_survey, lambda msg: msg.text == "Создать опрос"
         )
-        dp.message.register(self.process_title, StateFilter(SurveyStates.TITLE))
-        dp.message.register(
+        router.message.register(self.process_title, StateFilter(SurveyStates.TITLE))
+        router.message.register(
             self.process_description, StateFilter(SurveyStates.DESCRIPTION)
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_question_type_selection,
             lambda c: c.data.startswith("type_"),
             StateFilter(SurveyStates.QUESTION_TYPE),
         )
-        dp.message.register(
+        router.message.register(
             self.process_question_text, StateFilter(SurveyStates.QUESTION_TEXT)
         )
-        dp.message.register(
+        router.message.register(
             self.process_options, StateFilter(SurveyStates.ADDING_OPTIONS)
         )
-        dp.message.register(self.process_deadline, StateFilter(SurveyStates.DEADLINE))
-        dp.callback_query.register(
+        router.message.register(self.process_deadline, StateFilter(SurveyStates.DEADLINE))
+        router.callback_query.register(
             self.process_anonymity_selection,
             lambda c: c.data.startswith("anon_"),
             StateFilter(SurveyStates.ANONYMITY),
         )
-        dp.message.register(
+        router.message.register(
             self.process_target_groups, StateFilter(SurveyStates.TARGET_GROUPS)
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_scheduling_selection,
             lambda c: c.data.startswith("schedule_"),
             StateFilter(SurveyStates.SCHEDULING),
         )
-        dp.message.register(
+        router.message.register(
             self.process_schedule_date, StateFilter(SurveyStates.SCHEDULE_DATE)
         )
-        dp.message.register(
+        router.message.register(
             self.process_schedule_time, StateFilter(SurveyStates.SCHEDULE_TIME)
         )
-        dp.message.register(
+        router.message.register(
             self.process_confirmation, StateFilter(SurveyStates.CONFIRMATION)
         )
         # Дополнительные команды во время ввода вопросов
-        dp.message.register(
+        router.message.register(
             self.cmd_finish_questions,
             Command(commands=["finish_questions"]),
             StateFilter(
@@ -148,7 +148,7 @@ class SurveyPlugin:
                 SurveyStates.ADDING_OPTIONS,
             ),
         )
-        dp.message.register(
+        router.message.register(
             self.cmd_questions_count,
             Command(commands=["questions_count"]),
             StateFilter(
@@ -159,17 +159,17 @@ class SurveyPlugin:
         )
 
         # Обработчики управления опросами
-        dp.message.register(self.cmd_view_surveys, Command(commands=["view_surveys"]))
-        dp.message.register(self.cmd_view_surveys, lambda msg: msg.text == "Мои опросы")
-        dp.callback_query.register(
+        router.message.register(self.cmd_view_surveys, Command(commands=["view_surveys"]))
+        router.message.register(self.cmd_view_surveys, lambda msg: msg.text == "Мои опросы")
+        router.callback_query.register(
             self.process_survey_action, lambda c: c.data.startswith("survey_")
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.process_edit_question,
             lambda c: c.data.startswith("edit_q_"),
             StateFilter(SurveyStates.EDITING),
         )
-        dp.message.register(
+        router.message.register(
             self.process_edited_question, StateFilter(SurveyStates.EDITING_QUESTION)
         )
 

--- a/plugins/survey_templates_plugin.py
+++ b/plugins/survey_templates_plugin.py
@@ -5,7 +5,7 @@
 шаблонов, удалять их и создавать новые опросы на основе выбранного шаблона.
 """
 
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.filters import Command
 from datetime import datetime
 import uuid
@@ -41,11 +41,11 @@ class SurveyTemplatesPlugin:
         self.name = "survey_templates_plugin"
         self.description = "Шаблоны опросов"
 
-    async def register_handlers(self, dp: Dispatcher):
-        dp.message.register(self.cmd_save_template, Command("save_template"))
-        dp.message.register(self.cmd_list_templates, Command("list_templates"))
-        dp.message.register(self.cmd_delete_template, Command("delete_template"))
-        dp.message.register(self.cmd_use_template, Command("use_template"))
+    async def register_handlers(self, router: Router):
+        router.message.register(self.cmd_save_template, Command("save_template"))
+        router.message.register(self.cmd_list_templates, Command("list_templates"))
+        router.message.register(self.cmd_delete_template, Command("delete_template"))
+        router.message.register(self.cmd_use_template, Command("use_template"))
 
     def get_commands(self):
         return [

--- a/plugins/test_mode_plugin.py
+++ b/plugins/test_mode_plugin.py
@@ -1,4 +1,4 @@
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
@@ -43,15 +43,15 @@ class TestModePlugin:
         self.description = "Тестовый режим для опросов"
         self.test_surveys = {}
 
-    async def register_handlers(self, dp: Dispatcher):
-        dp.message.register(self.cmd_test_mode, Command("test_mode"))
-        dp.callback_query.register(
+    async def register_handlers(self, router: Router):
+        router.message.register(self.cmd_test_mode, Command("test_mode"))
+        router.callback_query.register(
             self.handle_survey_selection, lambda c: c.data.startswith("test_survey_")
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_test_action, lambda c: c.data.startswith("test_action_")
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_test_response, lambda c: c.data.startswith("test_response_")
         )
 

--- a/plugins/text_answer_plugin.py
+++ b/plugins/text_answer_plugin.py
@@ -5,7 +5,7 @@
 отображение и ввод пользователем.
 """
 
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -44,12 +44,12 @@ class TextAnswerPlugin(ResponseMixin):
         self.name = "text_answer_plugin"
         self.description = "Тип вопроса - текстовый ответ"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует все обработчики плагина"""
-        dp.callback_query.register(
+        router.callback_query.register(
             self.start_text_answer, lambda c: c.data.startswith("text_answer_")
         )
-        dp.message.register(
+        router.message.register(
             self.process_text_answer,
             StateFilter(TextAnswerStates.WAITING_FOR_ANSWER),  # Убираем 'state='
         )

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -5,7 +5,7 @@
 подробную информацию.
 """
 
-from aiogram import Dispatcher, types
+from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command, StateFilter
@@ -90,20 +90,20 @@ class ViewSurveysPlugin:
         self.name = "view_surveys"
         self.description = "Просмотр и управление опросами"
 
-    async def register_handlers(self, dp: Dispatcher):
+    async def register_handlers(self, router: Router):
         """Регистрирует все обработчики плагина"""
-        dp.message.register(self.cmd_view_surveys, Command("view_surveys"))
-        dp.callback_query.register(
+        router.message.register(self.cmd_view_surveys, Command("view_surveys"))
+        router.callback_query.register(
             self.handle_survey_selection,
             lambda c: c.data.startswith("view_survey_"),
             StateFilter(ViewSurveysStates.Viewing),
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_filter_selection,
             lambda c: c.data.startswith("filter_"),
             StateFilter(ViewSurveysStates.FilterMenu),
         )
-        dp.callback_query.register(
+        router.callback_query.register(
             self.handle_survey_action,
             lambda c: c.data.startswith("survey_action_"),
             StateFilter(ViewSurveysStates.ViewingDetails),

--- a/routers/menu_router.py
+++ b/routers/menu_router.py
@@ -1,0 +1,4 @@
+from aiogram import Router
+
+# Router for plugin commands and admin menu actions
+router = Router()

--- a/tests/test_admin_menu_integration.py
+++ b/tests/test_admin_menu_integration.py
@@ -174,8 +174,9 @@ def test_admin_menu_creates_survey(monkeypatch):
 
     pm_module = importlib.reload(importlib.import_module("plugin_manager"))
     dp = pm_module.Dispatcher()
+    router = pm_module.Router()
     bot = pm_module.Bot()
-    pm = pm_module.PluginManager(dp, bot)
+    pm = pm_module.PluginManager(dp, bot, router=router)
     asyncio.run(pm.load_plugins())
 
     admin = pm.get_plugin("admin_menu_plugin")

--- a/tests/test_admin_menu_plugins.py
+++ b/tests/test_admin_menu_plugins.py
@@ -61,7 +61,7 @@ def test_admin_menu_has_plugin_commands(monkeypatch):
     import plugin_manager as pm_module
 
     pm_module = importlib.reload(pm_module)
-    pm = pm_module.PluginManager(pm_module.Dispatcher(), pm_module.Bot())
+    pm = pm_module.PluginManager(pm_module.Dispatcher(), pm_module.Bot(), router=pm_module.Router())
     asyncio.run(pm.load_plugins())
     admin = pm.get_plugin("admin_menu_plugin")
     keyboards = admin.get_keyboards()

--- a/tests/test_plugin_manager_commands.py
+++ b/tests/test_plugin_manager_commands.py
@@ -24,7 +24,7 @@ def make_plugin_file(path: Path, command_name: str):
         """
 from aiogram.types import BotCommand
 class Plugin:
-    async def register_handlers(self, dp):
+    async def register_handlers(self, router):
         pass
     def get_commands(self):
         return [BotCommand(command='{cmd}', description='{cmd} desc')]
@@ -54,8 +54,9 @@ def test_setup_bot_commands_collects_from_plugins(tmp_path, monkeypatch):
     monkeypatch.setattr(aiogram.types, "BotCommand", DummyCommand)
 
     dp = aiogram.Dispatcher()
+    router = aiogram.Router()
     bot = DummyBot()
-    pm = PluginManager(dp, bot, plugin_dir=pkg_dir)
+    pm = PluginManager(dp, bot, plugin_dir=pkg_dir, router=router)
 
     asyncio.run(pm.load_plugins())
     asyncio.run(pm.setup_bot_commands(bot))
@@ -72,8 +73,9 @@ def test_plugins_load_from_env_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("PLUGIN_DIR", str(pkg_dir))
 
     dp = aiogram.Dispatcher()
+    router = aiogram.Router()
     bot = DummyBot()
-    pm = PluginManager(dp, bot, plugin_dir=os.getenv("PLUGIN_DIR"))
+    pm = PluginManager(dp, bot, plugin_dir=os.getenv("PLUGIN_DIR"), router=router)
 
     asyncio.run(pm.load_plugins())
 
@@ -105,8 +107,9 @@ def test_builtin_plugins_load_from_custom_package(tmp_path, monkeypatch):
     monkeypatch.setattr(aiogram, "Dispatcher", DummyDispatcher, raising=False)
 
     dp = aiogram.Dispatcher()
+    router = aiogram.Router()
     bot = DummyBot()
-    pm = PluginManager(dp, bot, plugin_dir=os.getenv("PLUGIN_DIR"))
+    pm = PluginManager(dp, bot, plugin_dir=os.getenv("PLUGIN_DIR"), router=router)
 
     asyncio.run(pm.load_plugins())
 


### PR DESCRIPTION
## Summary
- create `routers/menu_router.py` to centralize plugin registration
- update `PluginManager` to accept a router and include it when possible
- register plugins using the router and pass it from `main.py`
- adjust plugins and tests for the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbd7658e8832a81bdcb710bfbd33b