### PR TITLE
Add captcha event handlers

### DIFF
--- a/plugins/group_event_plugin.py
+++ b/plugins/group_event_plugin.py
@@ -5,9 +5,10 @@
 import os
 import logging
 import asyncio
-from aiogram.types import ChatPermissions
+from aiogram.types import ChatPermissions, ChatMemberUpdated, Message
 from aiogram.client.bot import Bot
 from aiogram import Router
+from aiogram.filters import ChatMemberUpdatedFilter
 from core.db_manager import (
     is_user_pending,
     remove_user_from_pending,
@@ -133,8 +134,33 @@ class GroupEventPlugin:
         self.cleanup_task = None
 
     async def register_handlers(self, router: Router):
-        # При необходимости здесь можно зарегистрировать обработчики событий группы.
-        pass
+        """Регистрирует обработчики событий группы."""
+        router.chat_member.register(
+            self.on_new_chat_member,
+            ChatMemberUpdatedFilter(member_status_changed=["member", "creator", "administrator"]),
+        )
+        router.message.register(
+            self.on_private_message, lambda m: getattr(m.chat, "type", "") == "private"
+        )
+
+    async def on_new_chat_member(self, event: ChatMemberUpdated):
+        user = event.from_user
+        if user.is_bot:
+            return
+        if ENABLE_CAPTCHA:
+            await restrict_user(event.bot, event.chat.id, user.id)
+            asyncio.create_task(start_captcha_timer(event.bot, user.id, event.chat.id))
+        else:
+            welcome = storage.get_setting("welcome_message", DEFAULT_WELCOME_MESSAGE)
+            try:
+                await event.bot.send_message(
+                    event.chat.id, welcome.format(username=user.full_name)
+                )
+            except Exception as e:
+                logger.error(f"Не удалось отправить приветственное сообщение: {e}")
+
+    async def on_private_message(self, message: Message):
+        await unrestrict_user_if_needed(message.bot, message.from_user.id)
 
     def get_commands(self):
         return []

--- a/tests/test_admin_menu_integration.py
+++ b/tests/test_admin_menu_integration.py
@@ -100,17 +100,18 @@ class DummyState:
 
 
 class DummyHandler:
+    def __init__(self):
+        self.handlers = []
+
     def __call__(self, *args, **kwargs):
         def decorator(func):
+            self.handlers.append(func)
             return func
 
         return decorator
 
-    def register(self, *args, **kwargs):
-        def decorator(func):
-            return func
-
-        return decorator
+    def register(self, handler, *args, **kwargs):
+        self.handlers.append(handler)
 
 
 class DummyDispatcher:
@@ -118,6 +119,16 @@ class DummyDispatcher:
         self.message = DummyHandler()
         self.callback_query = DummyHandler()
         self.chat_member = DummyHandler()
+
+
+class DummyRouter:
+    def __init__(self):
+        self.message = DummyHandler()
+        self.callback_query = DummyHandler()
+        self.chat_member = DummyHandler()
+
+    def include_router(self, *args, **kwargs):
+        pass
 
 
 class DummyTask:
@@ -131,9 +142,11 @@ async def no_task(*args, **kwargs):
 
 def test_admin_menu_creates_survey(monkeypatch):
     monkeypatch.setenv("ADMIN_IDS", "1")
+    monkeypatch.setenv("ENABLE_CAPTCHA", "True")
     monkeypatch.setenv("ENABLE_INACTIVE_CLEANUP", "False")
 
     monkeypatch.setattr(aiogram, "Dispatcher", DummyDispatcher, raising=False)
+    monkeypatch.setattr(aiogram, "Router", DummyRouter, raising=False)
     monkeypatch.setattr(aiogram.types, "BotCommand", DummyBotCommand, raising=False)
     monkeypatch.setattr(aiogram.types, "ReplyKeyboardMarkup", DummyMarkup, raising=False)
     monkeypatch.setattr(aiogram.types, "KeyboardButton", DummyButton, raising=False)
@@ -164,6 +177,20 @@ def test_admin_menu_creates_survey(monkeypatch):
     group_mod = importlib.reload(importlib.import_module("plugins.group_event_plugin"))
     monkeypatch.setattr(group_mod, "storage", storage, raising=False)
     monkeypatch.setattr(group_mod, "remove_inactive_users", lambda bot: None)
+    called = {}
+
+    async def fake_restrict(bot, chat_id, user_id):
+        called["restrict"] = (chat_id, user_id)
+
+    def fake_timer(bot, user_id, chat_id):
+        called["timer"] = (user_id, chat_id)
+
+    async def fake_unrestrict(bot, user_id):
+        called["unrestrict"] = user_id
+
+    monkeypatch.setattr(group_mod, "restrict_user", fake_restrict, raising=False)
+    monkeypatch.setattr(group_mod, "start_captcha_timer", fake_timer, raising=False)
+    monkeypatch.setattr(group_mod, "unrestrict_user_if_needed", fake_unrestrict, raising=False)
 
     importlib.reload(importlib.import_module("plugins.admin_menu_plugin"))
 
@@ -173,6 +200,35 @@ def test_admin_menu_creates_survey(monkeypatch):
     bot = pm_module.Bot()
     pm = pm_module.PluginManager(dp, bot, router=router)
     asyncio.run(pm.load_plugins())
+
+    group = pm.get_plugin("group_event_plugin")
+    assert group.on_new_chat_member in router.chat_member.handlers
+    assert group.on_private_message in router.message.handlers
+
+    event = type(
+        "Ev",
+        (),
+        {
+            "bot": bot,
+            "chat": type("C", (), {"id": 42})(),
+            "from_user": type("U", (), {"id": 1, "full_name": "U", "is_bot": False})(),
+        },
+    )()
+    asyncio.run(group.on_new_chat_member(event))
+    msg = type(
+        "Msg",
+        (),
+        {
+            "bot": bot,
+            "chat": type("Chat", (), {"type": "private", "id": 1})(),
+            "from_user": DummyUser(),
+        },
+    )()
+    asyncio.run(group.on_private_message(msg))
+
+    assert called["restrict"] == (42, 1)
+    assert called["timer"] == (1, 42)
+    assert called["unrestrict"] == 1
 
     admin = pm.get_plugin("admin_menu_plugin")
     survey = pm.get_plugin("survey_plugin")


### PR DESCRIPTION
## Summary
- register captcha and cleanup handlers in `group_event_plugin`
- check handler registration & invocation in admin menu integration test

## Testing
- `flake8 plugins/group_event_plugin.py tests/test_admin_menu_integration.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1baf1a94832a82086ca6a4752a1a