### PR TITLE
Add /start to bot command list

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -172,6 +172,10 @@ class PluginManager:
     async def setup_bot_commands(self, bot: Bot):
         """Настраивает команды бота на основе плагинов"""
         commands = self.get_all_commands()
+        if not any(cmd.command == "start" for cmd in commands):
+            commands.append(
+                BotCommand(command="start", description="Начать работу с ботом")
+            )
         if commands:
             await bot.set_my_commands(commands)
             logger.info(f"Установлено команд: {len(commands)}")


### PR DESCRIPTION
## Summary
- always register the start command when bot commands are set up

## Testing
- `pytest -q` *(fails: Admin menu tests and plugin command tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ee80e2680832a91ef71808d3836ae