### PR TITLE
Add pyproject config

### DIFF
--- a/migrations/versions/0001_initial.py
+++ b/migrations/versions/0001_initial.py
@@ -2,7 +2,6 @@
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import sqlite
 
 revision = "0001"
 down_revision = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kadron-bot"
+version = "0.1.0"
+description = "Telegram bot for managing polls with a plugin architecture"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Kadron Team", email = "contact@example.com"}]
+
+dependencies = [
+    "aiogram==3.0.0b7",
+    "python-dotenv",
+    "pandas",
+    "openpyxl",
+    "packaging",
+    "SQLAlchemy",
+    "alembic"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["tests*", "scripts*"]
+

--- a/tests/test_admin_plugin.py
+++ b/tests/test_admin_plugin.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+
 class DummyHandler:
     def __init__(self):
         self.handlers = []
@@ -13,6 +14,7 @@ class DummyHandler:
         self.handlers.append(handler)
 
     __call__ = register
+
 
 class DummyRouter:
     def __init__(self):
@@ -26,6 +28,7 @@ def test_admin_plugin_registers_handler(monkeypatch):
             sys.modules.pop(k)
 
     module = importlib.reload(importlib.import_module("plugins.admin_plugin"))
+
     class DummyBotCommand:
         def __init__(self, command=None, description=None):
             self.command = command

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -100,4 +100,3 @@ def test_get_user_ratings(tmp_path, monkeypatch):
     assert ratings[1].user_id == 2
     assert round(ratings[1].rating, 1) == 3.0
     assert ratings[1].feedback_count == 1
-

--- a/tests/test_plugin_unload_handlers.py
+++ b/tests/test_plugin_unload_handlers.py
@@ -1,6 +1,5 @@
 import asyncio
 import importlib
-import sys
 from pathlib import Path
 
 import aiogram


### PR DESCRIPTION
## Summary
- create `pyproject.toml` with project metadata and setuptools build backend
- fix flake8 issues in migrations and tests

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f7df91660832a8b54902902b3aecf