### PR TITLE
Add robust exception handling

### DIFF
--- a/core/db_manager.py
+++ b/core/db_manager.py
@@ -42,17 +42,18 @@ class UserRating:
 
 def initialize_db():
     """Create database tables."""
-    Base.metadata.create_all(
-        engine,
-        tables=[
-            Poll.__table__,
-            Question.__table__,
-            User.__table__,
-            Response.__table__,
-        ],
-    )
-    with sqlite3.connect(DATABASE) as conn:
-        cursor = conn.cursor()
+    try:
+        Base.metadata.create_all(
+            engine,
+            tables=[
+                Poll.__table__,
+                Question.__table__,
+                User.__table__,
+                Response.__table__,
+            ],
+        )
+        with sqlite3.connect(DATABASE) as conn:
+            cursor = conn.cursor()
         # Таблица тегов для опросов
         # Таблица тегов для опросов
         cursor.execute(
@@ -133,7 +134,11 @@ def initialize_db():
         """
         )
 
-    logger.info("Database initialized successfully.")
+        logger.info("Database initialized successfully.")
+
+    except Exception as e:
+        logger.exception(f"Failed to initialize database: {e}")
+        raise
 
 
 # --- Опросы ---

--- a/handlers/group_handlers.py
+++ b/handlers/group_handlers.py
@@ -20,11 +20,15 @@ async def handle_chat_member_update(event: types.ChatMemberUpdated):
     chat = event.chat
     user = event.from_user
 
-    add_group(chat.id, chat.title)
-    update_user_activity(user.id, user.username)
+    try:
+        add_group(chat.id, chat.title)
+        update_user_activity(user.id, user.username)
 
-    # Здесь можно добавить логику приветствия, капчи и т.д.
-    await bot.send_message(chat.id, f"Привет, {user.full_name}!")
+        # Здесь можно добавить логику приветствия, капчи и т.д.
+        await bot.send_message(chat.id, f"Привет, {user.full_name}!")
+    except Exception as e:
+        logger.exception(f"Ошибка обработки участника: {e}")
+        await bot.send_message(chat.id, "Произошла ошибка при добавлении участника")
 
 
 @router.message(lambda msg: msg.chat.type in ["group", "supergroup"])
@@ -32,8 +36,12 @@ async def handle_group_message(message: Message):
     """
     Пример простого хендлера, реагирующего на сообщения в группе/супергруппе
     """
-    update_user_activity(message.from_user.id, message.from_user.username)
-    add_group(message.chat.id, message.chat.title)
+    try:
+        update_user_activity(message.from_user.id, message.from_user.username)
+        add_group(message.chat.id, message.chat.title)
+    except Exception as e:
+        logger.exception(f"Ошибка обработки сообщения: {e}")
+        await message.answer("Произошла ошибка при обработке сообщения")
 
 
 def register_group_handlers(dp: Dispatcher):

--- a/handlers/survey_handlers.py
+++ b/handlers/survey_handlers.py
@@ -109,220 +109,245 @@ async def send_question(user_id: int, bot: Bot, state: FSMContext):
 
 @router.message(Command("start"))
 async def start_handler(message: types.Message, bot: Bot, state: FSMContext):
-    user_id = message.from_user.id
-    first_name = message.from_user.first_name or ""
-    last_name = message.from_user.last_name or ""
-    username = message.from_user.username or ""
-    update_user_activity(user_id, username)
-    await state.update_data(
-        first_name=first_name, last_name=last_name, username=username
-    )
-
-    # Извлекаем аргументы команды вручную из message.text
-    text = message.text or ""
-    parts = text.split(maxsplit=1)
-    args = parts[1] if len(parts) > 1 else ""
-
-    if args and args.startswith("survey_"):
-        try:
-            poll_id = int(args.split("_")[1])
-        except (ValueError, IndexError):
-            await message.answer("Неверная ссылка опроса.")
-            return
-        questions = get_questions(poll_id)
-        if not questions:
-            await message.answer("В этом опросе нет вопросов.")
-            return
+    try:
+        user_id = message.from_user.id
+        first_name = message.from_user.first_name or ""
+        last_name = message.from_user.last_name or ""
+        username = message.from_user.username or ""
+        update_user_activity(user_id, username)
         await state.update_data(
-            poll_id=poll_id, current_question_index=0, responses=[], selected_options={}
+            first_name=first_name, last_name=last_name, username=username
         )
-        await send_question(user_id, bot, state)
-        return
 
-    welcome_message = get_welcome_message()
-    if welcome_message:
-        welcome_text = welcome_message.replace(
-            "{username}", message.from_user.full_name
-        )
-    else:
-        welcome_text = "Добро пожаловать! Используйте /admin для доступа к административным функциям."
-    await message.answer(welcome_text)
+        # Извлекаем аргументы команды вручную из message.text
+        text = message.text or ""
+        parts = text.split(maxsplit=1)
+        args = parts[1] if len(parts) > 1 else ""
+
+        if args and args.startswith("survey_"):
+            try:
+                poll_id = int(args.split("_")[1])
+            except (ValueError, IndexError):
+                await message.answer("Неверная ссылка опроса.")
+                return
+            questions = get_questions(poll_id)
+            if not questions:
+                await message.answer("В этом опросе нет вопросов.")
+                return
+            await state.update_data(
+                poll_id=poll_id,
+                current_question_index=0,
+                responses=[],
+                selected_options={},
+            )
+            await send_question(user_id, bot, state)
+            return
+
+        welcome_message = get_welcome_message()
+        if welcome_message:
+            welcome_text = welcome_message.replace(
+                "{username}", message.from_user.full_name
+            )
+        else:
+            welcome_text = (
+                "Добро пожаловать! Используйте /admin для доступа к административным функциям."
+            )
+        await message.answer(welcome_text)
+    except Exception as e:
+        logger.exception(f"Ошибка в обработчике /start: {e}")
+        await message.answer("Произошла ошибка. Попробуйте позже.")
 
 
 @router.callback_query(lambda c: c.data and c.data.startswith("answer_"))
 async def answer_callback_handler(
     callback_query: types.CallbackQuery, state: FSMContext, bot: Bot
 ):
-    data = callback_query.data.split("_")
-    if len(data) != 3:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
-    _, q_index_str, opt_index_str = data
     try:
-        q_index = int(q_index_str)
-        opt_index = int(opt_index_str)
-    except ValueError:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
+        data = callback_query.data.split("_")
+        if len(data) != 3:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
+        _, q_index_str, opt_index_str = data
+        try:
+            q_index = int(q_index_str)
+            opt_index = int(opt_index_str)
+        except ValueError:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
 
-    current_data = await state.get_data()
-    poll_id = current_data.get("poll_id")
-    questions = get_questions(poll_id)
-    if q_index >= len(questions):
-        await bot.send_message(callback_query.from_user.id, "Вопрос не найден.")
-        return
+        current_data = await state.get_data()
+        poll_id = current_data.get("poll_id")
+        questions = get_questions(poll_id)
+        if q_index >= len(questions):
+            await bot.send_message(callback_query.from_user.id, "Вопрос не найден.")
+            return
 
-    question = questions[q_index]
-    try:
-        option = question["options"][opt_index]
-    except IndexError:
-        await bot.send_message(callback_query.from_user.id, "Выбран неверный вариант.")
-        return
+        question = questions[q_index]
+        try:
+            option = question["options"][opt_index]
+        except IndexError:
+            await bot.send_message(callback_query.from_user.id, "Выбран неверный вариант.")
+            return
 
-    responses = current_data.get("responses", [])
-    responses.append({"question": question["text"], "answer": option})
-    await state.update_data(responses=responses, current_question_index=q_index + 1)
-    poll_info = get_poll_by_id(poll_id)
-    db_user_id = (
-        None
-        if poll_info and poll_info.get("anonymous")
-        else callback_query.from_user.id
-    )
-    add_response(poll_id, question["id"], db_user_id, option, datetime.utcnow())
-    await bot.send_message(callback_query.from_user.id, f"Вы выбрали: {option}")
-    await send_question(callback_query.from_user.id, bot, state)
+        responses = current_data.get("responses", [])
+        responses.append({"question": question["text"], "answer": option})
+        await state.update_data(responses=responses, current_question_index=q_index + 1)
+        poll_info = get_poll_by_id(poll_id)
+        db_user_id = (
+            None if poll_info and poll_info.get("anonymous") else callback_query.from_user.id
+        )
+        add_response(poll_id, question["id"], db_user_id, option, datetime.utcnow())
+        await bot.send_message(callback_query.from_user.id, f"Вы выбрали: {option}")
+        await send_question(callback_query.from_user.id, bot, state)
+    except Exception as e:
+        logger.exception(f"Ошибка выбора варианта: {e}")
+        await bot.send_message(callback_query.from_user.id, "Произошла ошибка. Попробуйте позже.")
 
 
 @router.callback_query(lambda c: c.data and c.data.startswith("toggle_"))
 async def toggle_option_handler(
     callback_query: types.CallbackQuery, state: FSMContext, bot: Bot
 ):
-    data = callback_query.data.split("_")
-    if len(data) != 3:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
-    _, q_index_str, opt_index_str = data
     try:
-        q_index = int(q_index_str)
-        opt_index = int(opt_index_str)
-    except ValueError:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
+        data = callback_query.data.split("_")
+        if len(data) != 3:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
+        _, q_index_str, opt_index_str = data
+        try:
+            q_index = int(q_index_str)
+            opt_index = int(opt_index_str)
+        except ValueError:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
 
-    current_data = await state.get_data()
-    selected_options = current_data.get("selected_options", {})
-    key = str(q_index)
-    current_selection = selected_options.get(key, [])
-    if opt_index in current_selection:
-        current_selection.remove(opt_index)
-    else:
-        current_selection.append(opt_index)
-    selected_options[key] = current_selection
-    await state.update_data(selected_options=selected_options)
-    poll_id = current_data.get("poll_id")
-    questions = get_questions(poll_id)
-    if q_index >= len(questions):
-        return
-    question = questions[q_index]
-    buttons = []
-    for idx, option in enumerate(question["options"]):
-        btn_text = f"✅ {option}" if idx in current_selection else option
+        current_data = await state.get_data()
+        selected_options = current_data.get("selected_options", {})
+        key = str(q_index)
+        current_selection = selected_options.get(key, [])
+        if opt_index in current_selection:
+            current_selection.remove(opt_index)
+        else:
+            current_selection.append(opt_index)
+        selected_options[key] = current_selection
+        await state.update_data(selected_options=selected_options)
+        poll_id = current_data.get("poll_id")
+        questions = get_questions(poll_id)
+        if q_index >= len(questions):
+            return
+        question = questions[q_index]
+        buttons = []
+        for idx, option in enumerate(question["options"]):
+            btn_text = f"✅ {option}" if idx in current_selection else option
+            buttons.append(
+                [
+                    InlineKeyboardButton(
+                        text=btn_text, callback_data=f"toggle_{q_index}_{idx}"
+                    )
+                ]
+            )
         buttons.append(
-            [
-                InlineKeyboardButton(
-                    text=btn_text, callback_data=f"toggle_{q_index}_{idx}"
-                )
-            ]
+            [InlineKeyboardButton(text="Подтвердить", callback_data=f"confirm_{q_index}")]
         )
-    buttons.append(
-        [InlineKeyboardButton(text="Подтвердить", callback_data=f"confirm_{q_index}")]
-    )
-    keyboard = InlineKeyboardMarkup(inline_keyboard=buttons)
-    await bot.edit_message_reply_markup(
-        callback_query.message.chat.id,
-        callback_query.message.message_id,
-        reply_markup=keyboard,
-    )
-    await callback_query.answer()
+        keyboard = InlineKeyboardMarkup(inline_keyboard=buttons)
+        await bot.edit_message_reply_markup(
+            callback_query.message.chat.id,
+            callback_query.message.message_id,
+            reply_markup=keyboard,
+        )
+        await callback_query.answer()
+    except Exception as e:
+        logger.exception(f"Ошибка выбора опций: {e}")
+        await bot.send_message(callback_query.from_user.id, "Произошла ошибка. Попробуйте позже.")
 
 
 @router.callback_query(lambda c: c.data and c.data.startswith("confirm_"))
 async def confirm_multiple_handler(
     callback_query: types.CallbackQuery, state: FSMContext, bot: Bot
 ):
-    data = callback_query.data.split("_")
-    if len(data) != 2:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
     try:
-        q_index = int(data[1])
-    except ValueError:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
-    current_data = await state.get_data()
-    selected_options = current_data.get("selected_options", {}).get(str(q_index), [])
-    poll_id = current_data.get("poll_id")
-    questions = get_questions(poll_id)
-    if q_index >= len(questions):
-        await bot.send_message(callback_query.from_user.id, "Вопрос не найден.")
-        return
-    question = questions[q_index]
-    chosen = [
-        question["options"][i] for i in selected_options if i < len(question["options"])
-    ]
-    answer_text = ", ".join(chosen)
-    responses = current_data.get("responses", [])
-    responses.append({"question": question["text"], "answer": answer_text})
-    await state.update_data(responses=responses, current_question_index=q_index + 1)
-    poll_info = get_poll_by_id(poll_id)
-    db_user_id = (
-        None
-        if poll_info and poll_info.get("anonymous")
-        else callback_query.from_user.id
-    )
-    add_response(poll_id, question["id"], db_user_id, answer_text, datetime.utcnow())
-    selected_options_all = current_data.get("selected_options", {})
-    selected_options_all[str(q_index)] = []
-    await state.update_data(selected_options=selected_options_all)
-    await bot.send_message(callback_query.from_user.id, f"Ваш выбор: {answer_text}")
-    await send_question(callback_query.from_user.id, bot, state)
+        data = callback_query.data.split("_")
+        if len(data) != 2:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
+        try:
+            q_index = int(data[1])
+        except ValueError:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
+        current_data = await state.get_data()
+        selected_options = current_data.get("selected_options", {}).get(str(q_index), [])
+        poll_id = current_data.get("poll_id")
+        questions = get_questions(poll_id)
+        if q_index >= len(questions):
+            await bot.send_message(callback_query.from_user.id, "Вопрос не найден.")
+            return
+        question = questions[q_index]
+        chosen = [
+            question["options"][i] for i in selected_options if i < len(question["options"])
+        ]
+        answer_text = ", ".join(chosen)
+        responses = current_data.get("responses", [])
+        responses.append({"question": question["text"], "answer": answer_text})
+        await state.update_data(responses=responses, current_question_index=q_index + 1)
+        poll_info = get_poll_by_id(poll_id)
+        db_user_id = (
+            None if poll_info and poll_info.get("anonymous") else callback_query.from_user.id
+        )
+        add_response(poll_id, question["id"], db_user_id, answer_text, datetime.utcnow())
+        selected_options_all = current_data.get("selected_options", {})
+        selected_options_all[str(q_index)] = []
+        await state.update_data(selected_options=selected_options_all)
+        await bot.send_message(callback_query.from_user.id, f"Ваш выбор: {answer_text}")
+        await send_question(callback_query.from_user.id, bot, state)
+    except Exception as e:
+        logger.exception(f"Ошибка подтверждения выбора: {e}")
+        await bot.send_message(callback_query.from_user.id, "Произошла ошибка. Попробуйте позже.")
 
 
 @router.callback_query(lambda c: c.data and c.data.startswith("send_text_"))
 async def send_text_answer_handler(
     callback_query: types.CallbackQuery, state: FSMContext, bot: Bot
 ):
-    data = callback_query.data.split("_")
-    if len(data) != 3:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
-    _, action, q_index_str = data
     try:
-        q_index = int(q_index_str)
-    except ValueError:
-        await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
-        return
-    await bot.send_message(callback_query.from_user.id, "Введите ваш ответ:")
-    await state.update_data(current_question_index=q_index + 1)
-    await state.set_state("awaiting_text_answer")
+        data = callback_query.data.split("_")
+        if len(data) != 3:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
+        _, action, q_index_str = data
+        try:
+            q_index = int(q_index_str)
+        except ValueError:
+            await bot.send_message(callback_query.from_user.id, "Неверный формат ответа.")
+            return
+        await bot.send_message(callback_query.from_user.id, "Введите ваш ответ:")
+        await state.update_data(current_question_index=q_index + 1)
+        await state.set_state("awaiting_text_answer")
+    except Exception as e:
+        logger.exception(f"Ошибка текстового ответа: {e}")
+        await bot.send_message(callback_query.from_user.id, "Произошла ошибка. Попробуйте позже.")
 
 
 @router.message(StateFilter("awaiting_text_answer"))
 async def handle_text_answer(message: types.Message, state: FSMContext, bot: Bot):
-    user_id = message.from_user.id
-    answer = message.text.strip()
-    data = await state.get_data()
-    current_question_text = data.get("current_question_text", "Неизвестный вопрос")
-    question_id = data.get("current_question_id")
-    responses = data.get("responses", [])
-    responses.append({"question": current_question_text, "answer": answer})
-    await state.update_data(responses=responses)
-    poll_id = data.get("poll_id")
-    poll_info = get_poll_by_id(poll_id)
-    db_user_id = None if poll_info and poll_info.get("anonymous") else user_id
-    if question_id is not None:
-        add_response(poll_id, question_id, db_user_id, answer, datetime.utcnow())
-    await send_question(user_id, bot, state)
+    try:
+        user_id = message.from_user.id
+        answer = message.text.strip()
+        data = await state.get_data()
+        current_question_text = data.get("current_question_text", "Неизвестный вопрос")
+        question_id = data.get("current_question_id")
+        responses = data.get("responses", [])
+        responses.append({"question": current_question_text, "answer": answer})
+        await state.update_data(responses=responses)
+        poll_id = data.get("poll_id")
+        poll_info = get_poll_by_id(poll_id)
+        db_user_id = None if poll_info and poll_info.get("anonymous") else user_id
+        if question_id is not None:
+            add_response(poll_id, question_id, db_user_id, answer, datetime.utcnow())
+        await send_question(user_id, bot, state)
+    except Exception as e:
+        logger.exception(f"Ошибка обработки текстового ответа: {e}")
+        await message.answer("Произошла ошибка. Попробуйте позже.")
 
 
 def register_survey_handlers(dp: Dispatcher):

--- a/handlers/view_surveys_handler.py
+++ b/handlers/view_surveys_handler.py
@@ -9,11 +9,15 @@ logger = logging.getLogger(__name__)
 
 @router.message(Command("view_surveys"))
 async def view_surveys_handler(message: types.Message):
-    polls = get_all_polls()
-    if polls:
-        await message.answer("Список опросов:\n" + "\n".join(polls))
-    else:
-        await message.answer("Опросы не найдены.")
+    try:
+        polls = get_all_polls()
+        if polls:
+            await message.answer("Список опросов:\n" + "\n".join(polls))
+        else:
+            await message.answer("Опросы не найдены.")
+    except Exception as e:
+        logger.exception(f"Ошибка получения списка опросов: {e}")
+        await message.answer("Не удалось получить список опросов. Попробуйте позже.")
 
 
 def register_view_surveys_handler(dp: Dispatcher):

--- a/main.py
+++ b/main.py
@@ -55,7 +55,11 @@ logger.debug(f"ADMIN_IDS parsed: {ADMIN_IDS}")
 
 async def main():
     # Инициализация БД
-    initialize_db()
+    try:
+        initialize_db()
+    except Exception as e:
+        logger.exception(f"Ошибка инициализации базы данных: {e}")
+        return
 
     # Создание бота
     if DefaultBotProperties:
@@ -69,7 +73,10 @@ async def main():
     plugin_manager = PluginManager(dp, bot, plugin_dir=PLUGIN_DIR, router=menu_router)
 
     # Загружаем плагины
-    await plugin_manager.load_plugins()
+    try:
+        await plugin_manager.load_plugins()
+    except Exception as e:
+        logger.exception(f"Ошибка загрузки плагинов: {e}")
 
     # Регистрируем основные хендлеры
     register_survey_handlers(dp)

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -116,7 +116,9 @@ class PluginManager:
             return True
 
         except Exception as e:
-            logger.error(f"Не удалось выгрузить плагин {plugin_name}: {e}")
+            logger.exception(
+                f"Не удалось выгрузить плагин {plugin_name}: {e}"
+            )
             return False
 
     async def reload_plugin(self, plugin_name: str) -> bool:


### PR DESCRIPTION
## Summary
- wrap database initialization in try/except
- log stack traces and notify users in message handlers
- improve plugin unload logging
- handle plugin loading failures gracefully in `main`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas during collection)*
- `pip install -q -r requirements.txt` *(fails: building wheel for aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_686f93217074832a80c006a49388e382