### PR TITLE
Update bot command registration

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -173,6 +173,8 @@ class PluginManager:
 
     async def setup_bot_commands(self, bot: Bot):
         """Настраивает команды бота на основе плагинов"""
+        from aiogram.types import BotCommand
+
         commands = [BotCommand(command="start", description="Начать работу с ботом")]
         await bot.set_my_commands(commands)
         logger.info("Установлено команд: 1")


### PR DESCRIPTION
## Summary
- import `BotCommand` at runtime so tests can patch it

## Testing
- `pytest tests/test_plugin_manager_commands.py::test_setup_bot_commands_collects_from_plugins -q`
- `pytest -q` *(fails: InlineKeyboardMarkup() takes no arguments; database locked)*

------
https://chatgpt.com/codex/tasks/task_e_686fa86118fc832abefce2afd0881b02