### PR TITLE
Use logger in plugin template

### DIFF
--- a/plugin_template.py
+++ b/plugin_template.py
@@ -24,12 +24,16 @@
 - `unregister_handlers(router)` — удаляет зарегистрированные обработчики.
 """
 
+import logging
+
 from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+logger = logging.getLogger(__name__)
 
 
 class PluginStates(StatesGroup):
@@ -102,11 +106,11 @@ class PluginTemplate:
 
     def on_plugin_load(self):
         """Вызывается при загрузке плагина"""
-        print(f"Плагин {self.name} загружен")
+        logger.info("Плагин %s загружен", self.name)
 
     def on_plugin_unload(self):
         """Вызывается при выгрузке плагина"""
-        print(f"Плагин {self.name} выгружен")
+        logger.info("Плагин %s выгружен", self.name)
 
     async def handle_button(self, callback_query: types.CallbackQuery):
         """Обработчик нажатий на кнопки"""


### PR DESCRIPTION
## Summary
- configure a logger in `plugin_template`
- log plugin load/unload events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_686faaab6610832ab471b4c59fe60b67