### PR TITLE
Add plugin listing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ await pm.unload_plugin('test_mode_plugin')  # имя без .py
 ```python
 await pm.reload_plugin('test_mode_plugin')
 ```
+
+Получить список загруженных плагинов можно методом `list_plugin_names()`:
+
+```python
+names = pm.list_plugin_names()
+print(names)  # ['survey_plugin', 'admin_menu_plugin']
+```
 ## Примеры использования
 
 Ниже пример того, как выглядит административное меню:

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -20,7 +20,13 @@ logger = logging.getLogger(__name__)
 class PluginManager:
     """Управляет всеми плагинами бота"""
 
-    def __init__(self, dp: Dispatcher, bot: Bot, plugin_dir: str | None = None, router: Router | None = None):
+    def __init__(
+        self,
+        dp: Dispatcher,
+        bot: Bot,
+        plugin_dir: str | None = None,
+        router: Router | None = None,
+    ):
         self.dp = dp
         self.bot = bot
         self.router = router or Router()
@@ -59,6 +65,8 @@ class PluginManager:
             logger.debug(f"Loading plugin file: {filename}")
             plugin_name = filename[:-3]  # убираем расширение .py
             await self.load_plugin(plugin_name)
+
+        logger.info("Loaded plugins: %s", ", ".join(self.list_plugin_names()))
 
     async def load_plugin(self, plugin_name: str) -> bool:
         """Загружает конкретный плагин по имени"""
@@ -116,9 +124,7 @@ class PluginManager:
             return True
 
         except Exception as e:
-            logger.exception(
-                f"Не удалось выгрузить плагин {plugin_name}: {e}"
-            )
+            logger.exception(f"Не удалось выгрузить плагин {plugin_name}: {e}")
             return False
 
     async def reload_plugin(self, plugin_name: str) -> bool:
@@ -191,3 +197,7 @@ class PluginManager:
                 if plugin_keyboards:
                     keyboards.update(plugin_keyboards)
         return keyboards
+
+    def list_plugin_names(self) -> List[str]:
+        """Возвращает список имён загруженных плагинов"""
+        return list(self.plugins.keys())

--- a/tests/test_plugin_manager_list.py
+++ b/tests/test_plugin_manager_list.py
@@ -1,0 +1,44 @@
+import asyncio
+from pathlib import Path
+
+import aiogram
+from plugin_manager import PluginManager
+
+
+class DummyBot(aiogram.Bot):
+    pass
+
+
+def make_plugin_file(path: Path, name: str):
+    path.write_text(
+        f"""
+from aiogram.types import BotCommand
+class Plugin:
+    async def register_handlers(self, router):
+        pass
+    def get_commands(self):
+        return []
+
+def load_plugin(bot=None, plugin_manager=None):
+    return Plugin()
+"""
+    )
+
+
+def test_list_plugin_names(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / "pluglist"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    make_plugin_file(pkg_dir / "a_plugin.py", "a")
+    make_plugin_file(pkg_dir / "b_plugin.py", "b")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    dp = aiogram.Dispatcher()
+    router = aiogram.Router()
+    bot = DummyBot()
+    pm = PluginManager(dp, bot, plugin_dir=pkg_dir, router=router)
+
+    asyncio.run(pm.load_plugins())
+
+    assert set(pm.list_plugin_names()) == {"a_plugin", "b_plugin"}


### PR DESCRIPTION
## Summary
- extend PluginManager with `list_plugin_names`
- log loaded plugins after loading
- document plugin list method
- add tests for listing functionality

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687194d4f148832a84c95d25577c137e