### PR TITLE
Enable command registration in admin & template plugins

### DIFF
--- a/plugins/admin_plugin.py
+++ b/plugins/admin_plugin.py
@@ -7,6 +7,7 @@ Admin Plugin для Telegram бота.
 import logging
 from aiogram.client.bot import Bot
 from aiogram import Router, types
+from aiogram.filters import Command
 
 from core.db_manager import get_all_groups, get_poll_by_id
 from dotenv import load_dotenv
@@ -27,7 +28,7 @@ class AdminPlugin:
 
     async def register_handlers(self, router: Router):
         """Регистрирует обработчики административных команд"""
-        pass
+        router.message.register(self.cmd_send_survey, Command("send_survey"))
 
     async def unregister_handlers(self, router: Router):
         for attr in dir(router):

--- a/plugins/survey_templates_plugin.py
+++ b/plugins/survey_templates_plugin.py
@@ -42,7 +42,14 @@ class SurveyTemplatesPlugin:
         self.description = "Шаблоны опросов"
 
     async def register_handlers(self, router: Router):
-        pass
+        router.message.register(self.cmd_save_template, Command("save_template"))
+        router.message.register(
+            self.cmd_list_templates, Command("list_templates")
+        )
+        router.message.register(
+            self.cmd_delete_template, Command("delete_template")
+        )
+        router.message.register(self.cmd_use_template, Command("use_template"))
 
     async def unregister_handlers(self, router: Router):
         for attr in dir(router):

--- a/tests/test_admin_plugin.py
+++ b/tests/test_admin_plugin.py
@@ -39,6 +39,6 @@ def test_admin_plugin_registers_handler(monkeypatch):
     router = DummyRouter()
     asyncio.run(plugin.register_handlers(router))
 
-    assert plugin.cmd_send_survey not in router.message.handlers
+    assert plugin.cmd_send_survey in router.message.handlers
     cmds = plugin.get_commands()
     assert not cmds

--- a/tests/test_survey_templates_plugin.py
+++ b/tests/test_survey_templates_plugin.py
@@ -1,0 +1,33 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class DummyHandler:
+    def __init__(self):
+        self.handlers = []
+
+    def register(self, handler, *args, **kwargs):
+        self.handlers.append(handler)
+
+    __call__ = register
+
+
+class DummyRouter:
+    def __init__(self):
+        self.message = DummyHandler()
+
+
+def test_survey_templates_plugin_registers_commands(monkeypatch):
+    module = importlib.reload(importlib.import_module("plugins.survey_templates_plugin"))
+    plugin = module.load_plugin()
+    router = DummyRouter()
+    asyncio.run(plugin.register_handlers(router))
+
+    assert plugin.cmd_save_template in router.message.handlers
+    assert plugin.cmd_list_templates in router.message.handlers
+    assert plugin.cmd_delete_template in router.message.handlers
+    assert plugin.cmd_use_template in router.message.handlers


### PR DESCRIPTION
## Summary
- register `/send_survey` command in `AdminPlugin`
- wire up survey template commands
- adjust admin plugin test to expect command registration
- add tests for template plugin registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874da3fb110832a8d3f827ada72203e