### PR TITLE
Fix admin id parsing and plugin manager router

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -70,7 +70,9 @@ class PluginManager:
             await self.load_plugin(plugin_name)
 
         logger.info("Загружены плагины: %s", ", ".join(self.list_plugin_names()))
-        self.dp.include_router(self.router)
+        include = getattr(self.dp, "include_router", None)
+        if callable(include):
+            include(self.router)
 
     async def load_plugin(self, plugin_name: str) -> bool:
         """Загружает конкретный плагин по имени"""

--- a/utils/env_utils.py
+++ b/utils/env_utils.py
@@ -1,6 +1,15 @@
 import os
 import re
 
-def parse_admin_ids(value: str) -> list[int]:
-    """Парсит строку вида '123,456' в список int"""
-    return [int(x.strip()) for x in value.split(",") if x.strip().isdigit()]
+
+def parse_admin_ids(value: str | None = None) -> list[int]:
+    """Return a list of admin IDs from string or ``ADMIN_IDS`` env variable."""
+    if value is None:
+        value = os.getenv("ADMIN_IDS", "")
+
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+
+    ids = re.findall(r"\d+", value)
+    return [int(i) for i in ids]


### PR DESCRIPTION
## Summary
- allow `parse_admin_ids` to read from env when no argument
- skip router inclusion when dispatcher lacks `include_router`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687752ada558832a8de509426276f4ec