### PR TITLE
Fix E402 imports in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,14 @@ from utils.env_utils import parse_admin_ids
 
 # Загрузка переменных из .env
 from dotenv import load_dotenv
+
+from core.db_manager import initialize_db
+from plugin_manager import PluginManager
+from routers.menu_router import router as menu_router
+from handlers.survey_handlers import register_survey_handlers
+from handlers.group_handlers import register_group_handlers
+from handlers.view_surveys_handler import register_view_surveys_handler
+
 load_dotenv()
 
 try:
@@ -20,13 +28,6 @@ except ImportError:
     from aiogram.client.bot import Bot
     DefaultBotProperties = None
     logging.warning("DefaultBotProperties not found – bot will be created without parse_mode.")
-
-from core.db_manager import initialize_db
-from plugin_manager import PluginManager
-from routers.menu_router import router as menu_router
-from handlers.survey_handlers import register_survey_handlers
-from handlers.group_handlers import register_group_handlers
-from handlers.view_surveys_handler import register_view_surveys_handler
 
 configure_logging()
 


### PR DESCRIPTION
## Summary
- move imports for initialize_db, PluginManager, and routers/handlers to the top of `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' while installing requirements fails due to aiohttp wheel build error)*

------
https://chatgpt.com/codex/tasks/task_e_687809471968832a972fb6c0fab674d2