### PR TITLE
Fix F541 issue in tests

### DIFF
--- a/tests/test_plugin_manager_list.py
+++ b/tests/test_plugin_manager_list.py
@@ -11,7 +11,7 @@ class DummyBot(aiogram.Bot):
 
 def make_plugin_file(path: Path, name: str):
     path.write_text(
-        f"""
+        """
 from aiogram.types import BotCommand
 class Plugin:
     async def register_handlers(self, router):
@@ -21,7 +21,7 @@ class Plugin:
 
 def load_plugin(bot=None, plugin_manager=None):
     return Plugin()
-"""
+    """
     )
 
 


### PR DESCRIPTION
## Summary
- stop using f-string in test plugin

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780b1af3e8832abe94452326136bfd