### PR TITLE
Add comment clarifying router attachment guard

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -73,6 +73,7 @@ class PluginManager:
         include = getattr(self.dp, "include_router", None)
         parent = getattr(self.router, "parent_router", None)
         if callable(include) and parent is None:
+            # Ensure the router is attached only once
             include(self.router)
 
     async def load_plugin(self, plugin_name: str) -> bool:


### PR DESCRIPTION
## Summary
- clarify that the `include_router` call is guarded to run only once

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878ffb1ee4c832ab3f3777299d81a06