### PR TITLE
Update plugin names to explicit forms

### DIFF
--- a/plugins/edit_question_plugin.py
+++ b/plugins/edit_question_plugin.py
@@ -105,7 +105,7 @@ class EditQuestionPlugin:
     """Плагин для редактирования вопросов в опросах"""
 
     def __init__(self):
-        self.name = "edit_question"
+        self.name = "edit_question_plugin"
         self.description = "Редактировать вопросы в существующих опросах"
 
     async def register_handlers(self, router: Router):

--- a/plugins/view_surveys_plugin.py
+++ b/plugins/view_surveys_plugin.py
@@ -87,7 +87,7 @@ class ViewSurveysPlugin:
     """Плагин для просмотра опросов"""
 
     def __init__(self):
-        self.name = "view_surveys"
+        self.name = "view_surveys_plugin"
         self.description = "Просмотр и управление опросами"
 
     async def register_handlers(self, router: Router):


### PR DESCRIPTION
## Summary
- rename plugin names for clarity
- keep tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796556f988832a8ce968c4ee2e2b0b