### PR TITLE
Add send survey command

### DIFF
--- a/plugins/admin_menu_plugin.py
+++ b/plugins/admin_menu_plugin.py
@@ -175,6 +175,7 @@ class AdminMenuPlugin:
             [
                 [btn("Создать опрос", "surveys_create")],
                 [btn("Мои опросы", "surveys_my")],
+                [btn("Рассылка опроса", "surveys_send")],
                 [btn("Шаблоны вопросов", "surveys_templates")],
                 [btn("Настройки опросов", "surveys_settings")],
                 [btn("🔙 Назад", "admin_back")],

--- a/plugins/admin_plugin.py
+++ b/plugins/admin_plugin.py
@@ -43,7 +43,19 @@ class AdminPlugin:
             ]
 
     def get_commands(self):
-        return []
+        """Возвращает список команд плагина"""
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:
+            # Fallback for tests where BotCommand may be mocked elsewhere
+            from aiogram.types import BotCommand as BotCommandCls
+
+        return [
+            BotCommandCls(
+                command="send_survey",
+                description="Рассылка опроса",
+            )
+        ]
 
     async def cmd_send_survey(self, message: types.Message):
         """Команда для рассылки существующего опроса по группам"""

--- a/tests/test_admin_plugin.py
+++ b/tests/test_admin_plugin.py
@@ -41,4 +41,6 @@ def test_admin_plugin_registers_handler(monkeypatch):
 
     assert plugin.cmd_send_survey in router.message.handlers
     cmds = plugin.get_commands()
-    assert not cmds
+    assert len(cmds) == 1
+    assert cmds[0].command == "send_survey"
+    assert cmds[0].description == "Рассылка опроса"


### PR DESCRIPTION
## Summary
- add bot command for sending surveys
- expose send survey command in admin menu
- test for command description

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a1df64fc0832ab6eeb3631f96852a