### PR TITLE
Allow overriding plugin directories via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ cp example.env .env
 | `INACTIVITY_DAYS` | Количество дней неактивности до удаления (используется при включённой очистке) |
 | `WELCOME_MESSAGE` | Приветственное сообщение по умолчанию |
 | `PLUGIN_DIR` | Путь к каталогу плагинов (по умолчанию используются `plugins_admin` и `plugins_surveys`) |
+| `ADMIN_PLUGIN_DIR` | Путь к каталогу административных плагинов |
+| `SURVEY_PLUGIN_DIR` | Путь к каталогу плагинов опросов |
 
 ### Отладочное логирование
 
@@ -67,10 +69,13 @@ python main.py
 Важно запускать `main.py` из корня репозитория. Если стартовать бот из другого каталога
 (например, указав абсолютный путь к скрипту), менеджер плагинов может не найти
 плагины в папках `plugins_admin` и `plugins_surveys`. Для нестандартных случаев можно задать путь к каталогу
-плагинов через переменную окружения `PLUGIN_DIR`:
+плагинов через переменную окружения `PLUGIN_DIR` или задать каталоги отдельно
+через `ADMIN_PLUGIN_DIR` и `SURVEY_PLUGIN_DIR`:
 
 ```bash
-PLUGIN_DIR=/path/to/plugins python /absolute/path/to/main.py
+ADMIN_PLUGIN_DIR=/path/to/admin \
+SURVEY_PLUGIN_DIR=/path/to/surveys \
+python /absolute/path/to/main.py
 ```
 
 Начиная с версии с относительными импортами, пакет с плагинами может называться как угодно

--- a/example.env
+++ b/example.env
@@ -10,4 +10,6 @@ ENABLE_INACTIVE_CLEANUP=True
 INACTIVITY_DAYS=30
 WELCOME_MESSAGE=Привет, {username}! Добро пожаловать в нашу группу.
 # PLUGIN_DIR=plugins
+# ADMIN_PLUGIN_DIR=plugins_admin
+# SURVEY_PLUGIN_DIR=plugins_surveys
 

--- a/main.py
+++ b/main.py
@@ -48,6 +48,8 @@ if not BOT_TOKEN:
 ADMIN_IDS = parse_admin_ids(os.getenv("ADMIN_IDS", ""))
 
 PLUGIN_DIR = os.getenv("PLUGIN_DIR")
+ADMIN_PLUGIN_DIR = os.getenv("ADMIN_PLUGIN_DIR")
+SURVEY_PLUGIN_DIR = os.getenv("SURVEY_PLUGIN_DIR")
 
 logger = logging.getLogger(__name__)
 logger.debug(f"ADMIN_IDS parsed: {ADMIN_IDS}")
@@ -68,7 +70,14 @@ async def main():
     dp = Dispatcher()
     dp.include_router(menu_router)
 
-    plugin_manager = PluginManager(dp, bot, plugin_dir=PLUGIN_DIR, router=menu_router)
+    plugin_manager = PluginManager(
+        dp,
+        bot,
+        plugin_dir=PLUGIN_DIR,
+        admin_plugin_dir=ADMIN_PLUGIN_DIR,
+        survey_plugin_dir=SURVEY_PLUGIN_DIR,
+        router=menu_router,
+    )
 
     try:
         loaded = await plugin_manager.load_plugins(

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -10,6 +10,7 @@
 import importlib
 import inspect
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
@@ -38,15 +39,38 @@ class PluginManager:
         dp: Dispatcher,
         bot: Bot,
         plugin_dir: str | None = None,
+        *,
+        admin_plugin_dir: str | None = None,
+        survey_plugin_dir: str | None = None,
         router: Router | None = None,
     ):
+        """Create a plugin manager.
+
+        ``plugin_dir`` points to a single directory containing plugins or a
+        package with ``plugins_admin`` and ``plugins_surveys`` subdirectories.
+        ``admin_plugin_dir`` and ``survey_plugin_dir`` can be used to specify
+        directories separately. Environment variables ``ADMIN_PLUGIN_DIR`` and
+        ``SURVEY_PLUGIN_DIR`` override the respective arguments.
+        """
         self.dp = dp
         self.bot = bot
         self.router = router or Router()
         self.plugins: Dict[str, Any] = {}
 
         base = Path(__file__).resolve().parent
-        if plugin_dir:
+
+        env_admin = os.getenv("ADMIN_PLUGIN_DIR")
+        env_survey = os.getenv("SURVEY_PLUGIN_DIR")
+
+        admin_plugin_dir = admin_plugin_dir or env_admin
+        survey_plugin_dir = survey_plugin_dir or env_survey
+
+        if admin_plugin_dir or survey_plugin_dir:
+            self.plugin_dirs = [
+                Path(survey_plugin_dir or (base / "plugins_surveys")).resolve(),
+                Path(admin_plugin_dir or (base / "plugins_admin")).resolve(),
+            ]
+        elif plugin_dir:
             pd = Path(plugin_dir).resolve()
             if (pd / "plugins_admin").is_dir() and (pd / "plugins_surveys").is_dir():
                 self.plugin_dirs = [


### PR DESCRIPTION
## Summary
- support `ADMIN_PLUGIN_DIR` and `SURVEY_PLUGIN_DIR` in `PluginManager`
- expose the new variables in `main.py`
- document plugin directory overrides
- update `.env` example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4b71b720832a94047cb3e74ab37d