### PR TITLE
Add helper to clean plugin handlers

### DIFF
--- a/plugin_template.py
+++ b/plugin_template.py
@@ -32,6 +32,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from utils import remove_plugin_handlers
 
 logger = logging.getLogger(__name__)
 
@@ -63,16 +64,7 @@ class PluginTemplate:
 
     async def unregister_handlers(self, router: Router):
         """Удаляет все обработчики плагина из переданного ``Router``"""
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд, предоставляемых плагином"""

--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -7,6 +7,7 @@
 import logging
 from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
+from utils import remove_plugin_handlers
 
 
 from plugin_manager import PluginManager
@@ -127,16 +128,7 @@ class AdminMenuPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает команды плагина"""

--- a/plugins_admin/admin_plugin.py
+++ b/plugins_admin/admin_plugin.py
@@ -12,6 +12,7 @@ from aiogram.filters import Command
 from core.db_manager import get_all_groups, get_poll_by_id
 from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
+from utils import remove_plugin_handlers
 
 load_dotenv()
 ADMIN_IDS = parse_admin_ids()
@@ -31,16 +32,7 @@ class AdminPlugin:
         router.message.register(self.cmd_send_survey, Command("send_survey"))
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд плагина"""

--- a/plugins_admin/captcha_plugin.py
+++ b/plugins_admin/captcha_plugin.py
@@ -19,6 +19,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.filters import ChatMemberUpdatedFilter, StateFilter
 from core.db_manager import add_user_to_pending
 from .group_event_plugin import unrestrict_user_if_needed
+from utils import remove_plugin_handlers
 
 try:
     from .storage_plugin import storage
@@ -118,16 +119,7 @@ class CaptchaPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         return []

--- a/plugins_admin/group_event_plugin.py
+++ b/plugins_admin/group_event_plugin.py
@@ -16,6 +16,7 @@ from core.db_manager import (
     get_inactive_users,
     get_all_groups,
 )
+from utils import remove_plugin_handlers
 from dotenv import load_dotenv
 
 try:
@@ -148,16 +149,7 @@ class GroupEventPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     async def on_new_chat_member(self, event: ChatMemberUpdated):
         user = event.from_user

--- a/plugins_admin/roles_plugin.py
+++ b/plugins_admin/roles_plugin.py
@@ -11,6 +11,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import StateFilter
+from utils import remove_plugin_handlers
 
 # Импортируем модуль хранилища
 try:
@@ -108,16 +109,7 @@ class RolesPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд, предоставляемых плагином"""

--- a/plugins_admin/scheduler_plugin.py
+++ b/plugins_admin/scheduler_plugin.py
@@ -15,6 +15,7 @@ from aiogram import Router, types, Bot
 from aiogram.fsm.context import FSMContext  # <-- Вместо dispatcher.FSMContext
 from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.filters.state
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from utils import remove_plugin_handlers
 
 # Если используем собственное хранилище (storage_plugin)
 try:
@@ -109,16 +110,7 @@ class SchedulerPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращаем список команд, которые добавляет этот плагин (для /help и т.п.)"""

--- a/plugins_admin/storage_plugin.py
+++ b/plugins_admin/storage_plugin.py
@@ -8,6 +8,7 @@ import os
 import logging
 from typing import Dict, Any, Optional
 from aiogram import Router
+from utils import remove_plugin_handlers
 
 logger = logging.getLogger(__name__)
 
@@ -119,16 +120,7 @@ class StoragePlugin:
         pass
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Команды для этого плагина отсутствуют"""

--- a/plugins_surveys/edit_question_plugin.py
+++ b/plugins_surveys/edit_question_plugin.py
@@ -23,6 +23,7 @@ from core.db_manager import (
 import sqlite3
 from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
+from utils import remove_plugin_handlers
 from typing import List, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -154,16 +155,7 @@ class EditQuestionPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд плагина"""

--- a/plugins_surveys/export_plugin.py
+++ b/plugins_surveys/export_plugin.py
@@ -7,6 +7,7 @@ import os
 
 from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from utils import remove_plugin_handlers
 
 # Импорт хранилища
 try:
@@ -52,16 +53,7 @@ class ExportPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         return []

--- a/plugins_surveys/multiple_choice_plugin.py
+++ b/plugins_surveys/multiple_choice_plugin.py
@@ -12,6 +12,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import CallbackQuery, Message
 from core.db_manager import add_response
 from .response_mixin import ResponseMixin
+from utils import remove_plugin_handlers
 
 # Поправленные импорты для хранилища
 try:
@@ -56,16 +57,7 @@ class MultipleChoicePlugin(ResponseMixin):
         router.message.register(self.process_other_input)
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд плагина"""

--- a/plugins_surveys/single_choice_plugin.py
+++ b/plugins_surveys/single_choice_plugin.py
@@ -6,6 +6,7 @@ from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from core.db_manager import add_response
 from .response_mixin import ResponseMixin
+from utils import remove_plugin_handlers
 import logging
 
 try:
@@ -39,16 +40,7 @@ class SingleChoicePlugin(ResponseMixin):
         router.message.register(self.process_other_input)
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         return []

--- a/plugins_surveys/survey_plugin.py
+++ b/plugins_surveys/survey_plugin.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, time
 import asyncio
 import re
 from core.db_manager import get_all_groups
+from utils import remove_plugin_handlers
 
 # Импортируем модуль хранилища
 try:
@@ -176,16 +177,7 @@ class SurveyPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд, предоставляемых плагином"""

--- a/plugins_surveys/survey_templates_plugin.py
+++ b/plugins_surveys/survey_templates_plugin.py
@@ -10,6 +10,7 @@ from aiogram.filters import Command
 from datetime import datetime
 import uuid
 import logging
+from utils import remove_plugin_handlers
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +49,7 @@ class SurveyTemplatesPlugin:
         router.message.register(self.cmd_use_template, Command("use_template"))
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         return []

--- a/plugins_surveys/test_mode_plugin.py
+++ b/plugins_surveys/test_mode_plugin.py
@@ -5,6 +5,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 import logging
 import copy
+from utils import remove_plugin_handlers
 
 # Импорт хранилища
 try:
@@ -55,16 +56,7 @@ class TestModePlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         return []

--- a/plugins_surveys/text_answer_plugin.py
+++ b/plugins_surveys/text_answer_plugin.py
@@ -13,6 +13,7 @@ from aiogram.filters import StateFilter  # Добавляем фильтр со�
 import logging
 from core.db_manager import add_response
 from .response_mixin import ResponseMixin
+from utils import remove_plugin_handlers
 
 # Импорт хранилища из storage_plugin
 try:
@@ -55,16 +56,7 @@ class TextAnswerPlugin(ResponseMixin):
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд плагина"""

--- a/plugins_surveys/view_surveys_plugin.py
+++ b/plugins_surveys/view_surveys_plugin.py
@@ -11,6 +11,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import Command, StateFilter
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 import logging
+from utils import remove_plugin_handlers
 
 # Используем функции из db_manager вместо отсутствующего модуля базы данных
 from core.db_manager import (
@@ -110,16 +111,7 @@ class ViewSurveysPlugin:
         )
 
     async def unregister_handlers(self, router: Router):
-        for attr in dir(router):
-            event = getattr(router, attr)
-            handlers = getattr(event, "handlers", None)
-            if handlers is None:
-                continue
-            handlers[:] = [
-                h
-                for h in handlers
-                if getattr(getattr(h, "callback", h), "__self__", None) is not self
-            ]
+        remove_plugin_handlers(self, router)
 
     def get_commands(self):
         """Возвращает список команд плагина"""

--- a/tests/test_plugin_unload_handlers.py
+++ b/tests/test_plugin_unload_handlers.py
@@ -5,19 +5,25 @@ from pathlib import Path
 import aiogram
 
 from plugin_manager import PluginManager
+from utils import remove_plugin_handlers
 
 
 def make_plugin_file(path: Path):
     path.write_text(
         """
 from aiogram import Router
+from utils import remove_plugin_handlers
+
 class Plugin:
     async def register_handlers(self, router: Router):
         router.message.register(self.echo)
+
     async def unregister_handlers(self, router: Router):
-        router.message.handlers = [h for h in router.message.handlers if h != self.echo]
+        remove_plugin_handlers(self, router)
+
     async def echo(self, message):
         pass
+
     def get_commands(self):
         return []
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .aiogram_utils import remove_plugin_handlers

--- a/utils/aiogram_utils.py
+++ b/utils/aiogram_utils.py
@@ -1,0 +1,16 @@
+from aiogram import Router
+
+
+def remove_plugin_handlers(plugin, router: Router) -> None:
+    """Remove all handlers registered by a plugin from the router."""
+    for attr in dir(router):
+        event = getattr(router, attr)
+        handlers = getattr(event, "handlers", None)
+        if handlers is None:
+            continue
+        handlers[:] = [
+            h
+            for h in handlers
+            if getattr(getattr(h, "callback", h), "__self__", None) is not plugin
+        ]
+


### PR DESCRIPTION
## Summary
- centralize plugin handler cleanup in `utils.aiogram_utils.remove_plugin_handlers`
- refactor plugins to call the new helper
- update template and tests to use helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1918eb58832ab26f6d9b768e8131