### PR TITLE
Refactor survey plugins to use shared admin modules

### DIFF
--- a/plugins_surveys/export_plugin.py
+++ b/plugins_surveys/export_plugin.py
@@ -10,30 +10,13 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from utils import remove_plugin_handlers
 
 # Импорт хранилища
-try:
-    from .storage_plugin import storage
-except ImportError:
-
-    class DummyStorage:
-        def get_survey(self, survey_id):
-            return {}
-
-        def get_all_surveys(self):
-            return {}
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 # Импорт ролей для проверки прав
-try:
-    from .roles_plugin import RolesPlugin
+from plugins_admin.roles_plugin import RolesPlugin
 
-    roles_plugin = RolesPlugin()
-    has_permission = roles_plugin.has_permission
-except ImportError:
-
-    def has_permission(user_id, permission):
-        admin_ids = storage.get_setting("admin_ids", [])
-        return user_id in admin_ids
+roles_plugin = RolesPlugin()
+has_permission = roles_plugin.has_permission
 
 
 logger = logging.getLogger(__name__)

--- a/plugins_surveys/multiple_choice_plugin.py
+++ b/plugins_surveys/multiple_choice_plugin.py
@@ -15,24 +15,7 @@ from .response_mixin import ResponseMixin
 from utils import remove_plugin_handlers
 
 # Поправленные импорты для хранилища
-try:
-    from .storage_plugin import storage
-except ImportError:
-    # Запасной вариант для тестов
-    class DummyStorage:
-        def get_survey(self, survey_id):
-            return {}
-
-        def save_survey(self, survey_id, data):
-            pass
-
-        def get_user_state(self, user_id):
-            return {}
-
-        def set_user_state(self, user_id, key, value):
-            pass
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 logger = logging.getLogger(__name__)
 

--- a/plugins_surveys/single_choice_plugin.py
+++ b/plugins_surveys/single_choice_plugin.py
@@ -9,18 +9,7 @@ from .response_mixin import ResponseMixin
 from utils import remove_plugin_handlers
 import logging
 
-try:
-    from .storage_plugin import storage
-except ImportError:
-
-    class DummyStorage:
-        def get_survey(self, survey_id):
-            return {}
-
-        def save_survey(self, survey_id, data):
-            pass
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 logger = logging.getLogger(__name__)
 

--- a/plugins_surveys/survey_plugin.py
+++ b/plugins_surveys/survey_plugin.py
@@ -17,36 +17,7 @@ from core.db_manager import get_all_groups
 from utils import remove_plugin_handlers
 
 # Импортируем модуль хранилища
-try:
-    from .storage_plugin import storage
-except ImportError:
-    # Запасной вариант для тестирования
-    class DummyStorage:
-        def get_survey(self, survey_id):
-            return {}
-
-        def save_survey(self, survey_id, data):
-            pass
-
-        def get_all_surveys(self):
-            return {}
-
-        def delete_survey(self, survey_id):
-            pass
-
-        def get_user_state(self, user_id):
-            return {}
-
-        def set_user_state(self, user_id, key, value):
-            pass
-
-        def get_setting(self, key, default=None):
-            return default
-
-        def set_setting(self, key, value):
-            pass
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 logger = logging.getLogger(__name__)
 

--- a/plugins_surveys/survey_templates_plugin.py
+++ b/plugins_surveys/survey_templates_plugin.py
@@ -15,24 +15,7 @@ from utils import remove_plugin_handlers
 logger = logging.getLogger(__name__)
 
 # Используем хранилище из storage_plugin
-try:
-    from .storage_plugin import storage
-except Exception:
-
-    class DummyStorage:
-        def __init__(self):
-            self.data = {}
-
-        def get_survey(self, sid):
-            return None
-
-        def save_survey(self, sid, data):
-            pass
-
-        def _save_data(self):
-            pass
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 
 class SurveyTemplatesPlugin:

--- a/plugins_surveys/test_mode_plugin.py
+++ b/plugins_surveys/test_mode_plugin.py
@@ -8,27 +8,7 @@ import copy
 from utils import remove_plugin_handlers
 
 # Импорт хранилища
-try:
-    from .storage_plugin import storage
-except ImportError:
-
-    class DummyStorage:
-        def get_survey(self, survey_id):
-            return {}
-
-        def save_survey(self, survey_id, data):
-            pass
-
-        def get_setting(self, key, default=None):
-            return default
-
-        def set_setting(self, key, value):
-            pass
-
-        def get_all_surveys(self):
-            return {}
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 logger = logging.getLogger(__name__)
 

--- a/plugins_surveys/text_answer_plugin.py
+++ b/plugins_surveys/text_answer_plugin.py
@@ -16,18 +16,7 @@ from .response_mixin import ResponseMixin
 from utils import remove_plugin_handlers
 
 # Импорт хранилища из storage_plugin
-try:
-    from .storage_plugin import storage
-except ImportError:
-    # Запасной вариант для тестирования
-    class DummyStorage:
-        def get_survey(self, survey_id):
-            return {}
-
-        def save_survey(self, survey_id, data):
-            pass
-
-    storage = DummyStorage()
+from plugins_admin.storage_plugin import storage
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_storage_roles_integration.py
+++ b/tests/test_storage_roles_integration.py
@@ -1,0 +1,32 @@
+import asyncio
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import aiogram
+from plugin_manager import PluginManager
+
+
+class DummyBot(aiogram.Bot):
+    pass
+
+
+def test_survey_plugins_use_admin_storage_and_roles():
+    pm_module = importlib.reload(importlib.import_module("plugin_manager"))
+    dp = pm_module.Dispatcher()
+    router = pm_module.Router()
+    bot = DummyBot()
+    pm = pm_module.PluginManager(dp, bot, router=router)
+    asyncio.run(pm.load_plugins())
+
+    import plugins_admin.storage_plugin as sp
+    import plugins_admin.roles_plugin as rp
+    import plugins_surveys.survey_plugin as surv
+    import plugins_surveys.export_plugin as exp
+
+    assert surv.storage is sp.storage
+    assert exp.storage is sp.storage
+    assert isinstance(exp.roles_plugin, rp.RolesPlugin)
+


### PR DESCRIPTION
## Summary
- reuse storage and roles implementations from admin plugins
- remove dummy fallbacks in survey plugins
- verify that the storage and roles objects are shared

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de6528f00832aac38ff5bd4149a1b