### PR TITLE
Clean up command handlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,16 +60,6 @@ logger.debug(f"ADMIN_IDS parsed: {ADMIN_IDS}")
 router = Router()
 
 
-@router.message(CommandStart())
-async def start_command(message: types.Message):
-    await message.answer("Запуск")
-
-
-@router.message(Command("admin"))
-async def admin_command(message: types.Message):
-    await message.answer("Админ-панель")
-
-
 async def main():
     try:
         initialize_db()
@@ -114,12 +104,6 @@ async def main():
     register_group_handlers(dp)
 
     await plugin_manager.setup_bot_commands(bot)
-    await bot.set_my_commands(
-        [
-            BotCommand(command="start", description="Запуск"),
-            BotCommand(command="admin", description="Админ-панель"),
-        ]
-    )
 
     logger.info("Бот запущен и ожидает обновлений...")
     allowed_updates = dp.resolve_used_update_types()


### PR DESCRIPTION
## Summary
- remove duplicated `/start` and `/admin` handlers from `main.py`
- rely on `PluginManager.setup_bot_commands` for bot command registration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e08567bfc832a8a54e59830d74707