### PR TITLE
Apply black formatting and resolve flake8 warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,10 +5,8 @@ import logging
 import os
 
 from aiogram import __version__ as aiogram_version
-from aiogram import Dispatcher, Router, types
+from aiogram import Dispatcher, Router
 from aiogram.enums import ParseMode
-from aiogram.filters import CommandStart, Command
-from aiogram.types import BotCommand
 from packaging.version import parse as parse_version
 from utils.logging_utils import configure_logging
 from utils.env_utils import parse_admin_ids
@@ -28,6 +26,7 @@ try:
     from aiogram.client.bot import Bot, DefaultBotProperties
 except ImportError:  # pragma: no cover - older aiogram
     from aiogram.client.bot import Bot
+
     DefaultBotProperties = None
     logging.warning(
         "DefaultBotProperties not found – bot will be created with parse_mode parameter"
@@ -68,10 +67,11 @@ async def main():
         return
 
     if DefaultBotProperties:
-        bot = Bot(token=BOT_TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
+        bot = Bot(
+            token=BOT_TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML)
+        )
     else:
         bot = Bot(token=BOT_TOKEN, parse_mode=ParseMode.HTML)
-
 
     dp = Dispatcher()
     dp.include_router(router)

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -24,9 +24,8 @@ class MissingRequiredPluginsError(Exception):
 
     def __init__(self, missing: List[str]):
         self.missing = missing
-        super().__init__(
-            f"Required plugins missing: {', '.join(missing)}"
-        )
+        super().__init__(f"Required plugins missing: {', '.join(missing)}")
+
 
 logger = logging.getLogger(__name__)
 

--- a/plugins_surveys/survey_templates_plugin.py
+++ b/plugins_surveys/survey_templates_plugin.py
@@ -11,11 +11,9 @@ from datetime import datetime
 import uuid
 import logging
 from utils import remove_plugin_handlers
+from plugins_admin.storage_plugin import storage
 
 logger = logging.getLogger(__name__)
-
-# Используем хранилище из storage_plugin
-from plugins_admin.storage_plugin import storage
 
 
 class SurveyTemplatesPlugin:

--- a/tests/test_plugin_unload_handlers.py
+++ b/tests/test_plugin_unload_handlers.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import aiogram
 
 from plugin_manager import PluginManager
-from utils import remove_plugin_handlers
 
 
 def make_plugin_file(path: Path):

--- a/tests/test_storage_roles_integration.py
+++ b/tests/test_storage_roles_integration.py
@@ -3,10 +3,9 @@ import importlib
 from pathlib import Path
 import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 import aiogram
-from plugin_manager import PluginManager
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 class DummyBot(aiogram.Bot):
@@ -29,4 +28,3 @@ def test_survey_plugins_use_admin_storage_and_roles():
     assert surv.storage is sp.storage
     assert exp.storage is sp.storage
     assert isinstance(exp.roles_plugin, rp.RolesPlugin)
-

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,3 @@
 from .aiogram_utils import remove_plugin_handlers
+
+__all__ = ["remove_plugin_handlers"]

--- a/utils/aiogram_utils.py
+++ b/utils/aiogram_utils.py
@@ -13,4 +13,3 @@ def remove_plugin_handlers(plugin, router: Router) -> None:
             for h in handlers
             if getattr(getattr(h, "callback", h), "__self__", None) is not plugin
         ]
-


### PR DESCRIPTION
## Summary
- reformat repository using `black` with line length 88
- clean imports and blank lines in `main.py` and `plugin_manager.py`
- fix module level import order in `survey_templates_plugin`
- tidy test modules and expose util function in `__all__`

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_687e0ad934a0832ab77793a3b867c93c