### PR TITLE
Improve PluginManager load error handling

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -27,6 +27,16 @@ class MissingRequiredPluginsError(Exception):
         super().__init__(f"Required plugins missing: {', '.join(missing)}")
 
 
+class PluginLoadError(Exception):
+    """Raised when a plugin cannot be imported or initialized."""
+
+    def __init__(self, plugin_name: str, original: Exception):
+        self.plugin_name = plugin_name
+        self.original = original
+        msg = f"Failed to load plugin {plugin_name}: {type(original).__name__}: {original}"
+        super().__init__(msg)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -150,19 +160,30 @@ class PluginManager:
             logger.warning(f"Плагин {plugin_name} уже загружен")
             return False
 
+        pkg = package or self.plugin_packages.get(plugin_name)
+        if not pkg:
+            for pd, pk in zip(self.plugin_dirs, self._packages):
+                if (pd / f"{plugin_name}.py").exists() or (
+                    pd / f"{plugin_name}_plugin.py"
+                ).exists():
+                    pkg = pk
+                    break
+        if not pkg:
+            pkg = self._packages[0]
         try:
-            pkg = package or self.plugin_packages.get(plugin_name)
-            if not pkg:
-                for pd, pk in zip(self.plugin_dirs, self._packages):
-                    if (pd / f"{plugin_name}.py").exists() or (
-                        pd / f"{plugin_name}_plugin.py"
-                    ).exists():
-                        pkg = pk
-                        break
-            if not pkg:
-                pkg = self._packages[0]
             module = importlib.import_module(f"{pkg}.{plugin_name}")
-            self.plugin_packages[plugin_name] = pkg
+        except ImportError as e:
+            logger.error(
+                "Не удалось импортировать плагин %s: %s: %s",
+                plugin_name,
+                type(e).__name__,
+                e,
+            )
+            raise PluginLoadError(plugin_name, e) from e
+
+        self.plugin_packages[plugin_name] = pkg
+
+        try:
             sig = inspect.signature(module.load_plugin)
             kwargs = {}
             if "bot" in sig.parameters:
@@ -175,14 +196,18 @@ class PluginManager:
 
             if hasattr(plugin, "on_plugin_load"):
                 plugin.on_plugin_load()
-
-            self.plugins[plugin_name] = plugin
-            logger.info(f"Плагин {plugin_name} успешно загружен")
-            return True
-
         except Exception as e:
-            logger.exception(f"Не удалось загрузить плагин {plugin_name}: {e}")
-            return False
+            logger.exception(
+                "Ошибка инициализации плагина %s: %s: %s",
+                plugin_name,
+                type(e).__name__,
+                e,
+            )
+            raise PluginLoadError(plugin_name, e) from e
+
+        self.plugins[plugin_name] = plugin
+        logger.info(f"Плагин {plugin_name} успешно загружен")
+        return True
 
     async def unload_plugin(self, plugin_name: str) -> bool:
         """Выгружает конкретный плагин по имени"""

--- a/tests/test_plugin_manager_errors.py
+++ b/tests/test_plugin_manager_errors.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import aiogram  # noqa: E402
+from plugin_manager import PluginManager  # noqa: E402
+import plugin_manager  # noqa: E402
+
+
+class DummyBot(aiogram.Bot):
+    pass
+
+
+def test_load_plugin_import_error_logs_and_raises(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / "badpkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    dp = aiogram.Dispatcher()
+    router = aiogram.Router()
+    bot = DummyBot()
+    pm = PluginManager(dp, bot, plugin_dir=pkg_dir, router=router)
+
+    messages = []
+
+    def fake_error(msg, *args, **kwargs):
+        if args:
+            msg = msg % args
+        messages.append(msg)
+
+    monkeypatch.setattr(plugin_manager.logger, "error", fake_error)
+
+    with pytest.raises(plugin_manager.PluginLoadError):
+        asyncio.run(pm.load_plugin("missing_plugin"))
+
+    assert messages
+    assert "missing_plugin" in messages[0]
+    assert "ModuleNotFoundError" in messages[0]


### PR DESCRIPTION
## Summary
- capture ImportError separately when loading plugins
- log import vs initialization errors with details
- raise new `PluginLoadError` on plugin load failures
- test that failed imports log details and raise the new exception

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2e521400832ab5342c251e65d3a8