### PR TITLE
Remove extra dotenv calls

### DIFF
--- a/core/db_manager.py
+++ b/core/db_manager.py
@@ -9,9 +9,7 @@ from typing import List, Dict, Optional
 from dataclasses import dataclass
 import logging
 import os
-from dotenv import load_dotenv
 
-load_dotenv()
 DATABASE = os.getenv("DATABASE", "database.db")
 logger = logging.getLogger(__name__)
 

--- a/handlers/group_handlers.py
+++ b/handlers/group_handlers.py
@@ -3,10 +3,8 @@
 import logging
 from aiogram import Router, Dispatcher, types
 from aiogram.types import Message
-from dotenv import load_dotenv
 from core.db_manager import add_group, update_user_activity
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 router = Router()
 

--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -5,7 +5,6 @@
 """
 
 import logging
-from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
 from utils import remove_plugin_handlers
 
@@ -23,9 +22,6 @@ from plugins_surveys.export_plugin import ExportPlugin
 from plugins_surveys.test_mode_plugin import TestModePlugin
 from plugins_surveys.survey_templates_plugin import SurveyTemplatesPlugin
 from .roles_plugin import RolesPlugin
-
-# Загружаем переменные из .env файла
-load_dotenv()
 
 logger = logging.getLogger(__name__)
 

--- a/plugins_admin/admin_plugin.py
+++ b/plugins_admin/admin_plugin.py
@@ -10,11 +10,9 @@ from aiogram import Router, types
 from aiogram.filters import Command
 
 from core.db_manager import get_all_groups, get_poll_by_id
-from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
 from utils import remove_plugin_handlers
 
-load_dotenv()
 ADMIN_IDS = parse_admin_ids()
 logger = logging.getLogger(__name__)
 logger.debug(f"Parsed ADMIN_IDS: {ADMIN_IDS}")

--- a/plugins_admin/group_event_plugin.py
+++ b/plugins_admin/group_event_plugin.py
@@ -17,7 +17,6 @@ from core.db_manager import (
     get_all_groups,
 )
 from utils import remove_plugin_handlers
-from dotenv import load_dotenv
 
 try:
     from .storage_plugin import storage
@@ -28,8 +27,6 @@ except ImportError:
             return default
 
     storage = DummyStorage()
-
-load_dotenv()
 
 ENABLE_CAPTCHA = os.getenv("ENABLE_CAPTCHA", "False").lower() == "true"
 CAPTCHA_TIMEOUT = int(os.getenv("CAPTCHA_TIMEOUT", "5"))

--- a/plugins_surveys/edit_question_plugin.py
+++ b/plugins_surveys/edit_question_plugin.py
@@ -21,14 +21,12 @@ from core.db_manager import (
     get_questions_by_poll,
 )
 import sqlite3
-from dotenv import load_dotenv
 from utils.env_utils import parse_admin_ids
 from utils import remove_plugin_handlers
 from typing import List, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-load_dotenv()
 ADMIN_IDS = parse_admin_ids()
 
 

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,11 +1,9 @@
 import logging
 import os
-from dotenv import load_dotenv
 
 
 def configure_logging():
-    """Load env vars and configure logging level."""
-    load_dotenv()
+    """Configure logging level from environment."""
     level_name = os.getenv("LOGGING_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
     logging.basicConfig(level=level, force=True)


### PR DESCRIPTION
## Summary
- ensure plugins don't call `load_dotenv`
- rely on environment loading in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e373b1814832abf88ffec16b31185