### PR TITLE
Dynamic admin menu from plugin metadata

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -192,6 +192,11 @@ class PluginManager:
                 kwargs["plugin_manager"] = self
             plugin = module.load_plugin(**kwargs)
 
+            # attach meta-data defined on module level
+            plugin_meta = getattr(module, "__plugin_meta__", None)
+            if plugin_meta is not None:
+                setattr(plugin, "__plugin_meta__", plugin_meta)
+
             await plugin.register_handlers(self.router)
 
             if hasattr(plugin, "on_plugin_load"):
@@ -253,14 +258,63 @@ class PluginManager:
     def get_all_plugins(self) -> Dict[str, Any]:
         return self.plugins
 
+    def get_admin_menu_items(self) -> List[Dict[str, str]]:
+        """Собирает пункты административного меню из мета-данных плагинов."""
+        items: List[Dict[str, str]] = []
+        for name, plugin in self.plugins.items():
+            meta = getattr(plugin, "__plugin_meta__", None)
+            if not meta:
+                continue
+            menu = meta.get("admin_menu")
+            if menu is None:
+                continue
+            if not isinstance(menu, list):
+                logger.warning(f"admin_menu в плагине {name} должен быть списком")
+                continue
+            for item in menu:
+                if (
+                    isinstance(item, dict)
+                    and isinstance(item.get("text"), str)
+                    and isinstance(item.get("callback"), str)
+                ):
+                    items.append({"text": item["text"], "callback": item["callback"]})
+                else:
+                    logger.warning(
+                        f"Неверный элемент admin_menu в плагине {name}: {item}"
+                    )
+        return items
+
     def get_all_commands(self) -> List[BotCommand]:
         commands = []
-        for plugin in self.plugins.values():
+        for name, plugin in self.plugins.items():
             if hasattr(plugin, "get_commands"):
                 try:
                     commands.extend(plugin.get_commands() or [])
                 except Exception as e:
                     logger.warning(f"Ошибка get_commands у {plugin.name}: {e}")
+
+            meta = getattr(plugin, "__plugin_meta__", None)
+            if not meta:
+                continue
+            meta_cmds = meta.get("commands")
+            if meta_cmds is None:
+                continue
+            if not isinstance(meta_cmds, list):
+                logger.warning(f"commands в плагине {name} должен быть списком")
+                continue
+            for cmd in meta_cmds:
+                if (
+                    isinstance(cmd, dict)
+                    and isinstance(cmd.get("command"), str)
+                    and isinstance(cmd.get("description", ""), str)
+                ):
+                    commands.append(
+                        BotCommand(command=cmd["command"], description=cmd.get("description", ""))
+                    )
+                else:
+                    logger.warning(
+                        f"Неверный элемент commands в плагине {name}: {cmd}"
+                    )
         return commands
 
     def get_plugin_commands(self) -> Dict[str, List[BotCommand]]:
@@ -270,6 +324,25 @@ class PluginManager:
                 plugin_commands[name] = plugin.get_commands() or []
             else:
                 plugin_commands[name] = []
+
+            meta = getattr(plugin, "__plugin_meta__", None)
+            if meta and isinstance(meta.get("commands"), list):
+                for cmd in meta["commands"]:
+                    if (
+                        isinstance(cmd, dict)
+                        and isinstance(cmd.get("command"), str)
+                        and isinstance(cmd.get("description", ""), str)
+                    ):
+                        plugin_commands[name].append(
+                            BotCommand(
+                                command=cmd["command"],
+                                description=cmd.get("description", ""),
+                            )
+                        )
+                    else:
+                        logger.warning(
+                            f"Неверный элемент commands в плагине {name}: {cmd}"
+                        )
         return plugin_commands
 
     async def setup_bot_commands(self, bot: Bot):

--- a/plugin_template.py
+++ b/plugin_template.py
@@ -26,6 +26,15 @@
 
 import logging
 
+__plugin_meta__ = {
+    "admin_menu": [
+        {"text": "⚙ Шаблон", "callback": "template_command"},
+    ],
+    "commands": [
+        {"command": "template_command", "description": "Шаблонная команда"},
+    ],
+}
+
 from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup

--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -1,321 +1,93 @@
 """
-Плагин административного меню для Telegram-бота.
+Admin menu plugin providing access to other plugin features.
 
-Обеспечивает функциональность меню администратора с поддержкой состояний.
+The inline keyboard is built dynamically based on meta-data declared in
+loaded plugins. Each plugin can expose menu entries via ``__plugin_meta__``
+variable:
+
+__plugin_meta__ = {
+    "admin_menu": [
+        {"text": "📊 Просмотр опросов", "callback": "view_surveys"},
+    ],
+    "commands": [
+        {"command": "view_surveys", "description": "Просмотр всех опросов"},
+    ],
+}
 """
 
 import logging
-from utils.env_utils import parse_admin_ids
-from utils import remove_plugin_handlers
-
 
 from plugin_manager import PluginManager
 from aiogram import Router, types
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import State, StatesGroup
-from aiogram.filters import Command, StateFilter
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.filters import Command
 
-# Fallback plugin classes in case dependencies are missing
-from plugins_surveys.survey_plugin import SurveyPlugin
-from plugins_surveys.export_plugin import ExportPlugin
-from plugins_surveys.test_mode_plugin import TestModePlugin
-from plugins_surveys.survey_templates_plugin import SurveyTemplatesPlugin
-from .roles_plugin import RolesPlugin
+from utils.env_utils import parse_admin_ids
+from utils import remove_plugin_handlers
 
 logger = logging.getLogger(__name__)
 
 
-class AdminMenuStates(StatesGroup):
-    """Состояния для административного меню"""
-
-    MAIN_MENU = State()  # Главное меню
-    SURVEYS_MENU = State()  # Меню опросов
-    ANALYTICS_MENU = State()  # Меню аналитики
-    SETTINGS_MENU = State()  # Меню настроек
+__plugin_meta__ = {
+    "commands": [
+        {"command": "admin", "description": "Админ меню"},
+    ]
+}
 
 
 class AdminMenuPlugin:
-    """Плагин административного меню"""
+    """Plugin that shows admin menu generated from plugin meta-data."""
 
     def __init__(self, plugin_manager: PluginManager):
         self.name = "admin_menu_plugin"
-        self.description = "Функциональность административного меню"
-        # Загружаем admin_ids из переменной окружения
+        self.description = "Административное меню"
         self.admin_ids = parse_admin_ids()
-        logger.debug(f"Parsed admin_ids: {self.admin_ids}")
         self.plugin_manager = plugin_manager
 
-        # Resolve plugin dependencies using helper
-        self.survey_plugin = self._get_or_create("survey_plugin", SurveyPlugin)
-        self.export_plugin = self._get_or_create("export_plugin", ExportPlugin)
-        self.test_mode_plugin = self._get_or_create("test_mode_plugin", TestModePlugin)
-        self.templates_plugin = self._get_or_create(
-            "survey_templates_plugin", SurveyTemplatesPlugin
-        )
-        self.roles_plugin = self._get_or_create("roles_plugin", RolesPlugin)
-
-    def _get_or_create(self, plugin_name: str, cls):
-        """Fetches a plugin from PluginManager or raises if missing."""
-        plugin = self.plugin_manager.get_plugin(plugin_name)
-        if plugin:
-            return plugin
-        logger.error(
-            f"Dependency '{plugin_name}' not found in PluginManager. "
-            f"'{self.name}' requires all dependencies to be loaded."
-        )
-        raise RuntimeError(
-            f"Dependency '{plugin_name}' must be loaded via PluginManager"
-        )
-
     async def register_handlers(self, router: Router):
-        """Регистрирует все обработчики для плагина"""
         router.message.register(self.cmd_admin_menu, Command("admin"))
         router.callback_query.register(
-            self.admin_menu_callback,
-            lambda c: c.data == "admin_menu",
-        )
-        router.callback_query.register(
-            self.handle_main_menu,
-            lambda c: c.data in {"admin_surveys", "admin_analytics", "admin_settings"},
-            StateFilter(AdminMenuStates.MAIN_MENU),
-        )
-        router.callback_query.register(
-            self.handle_back,
-            lambda c: c.data == "admin_back",
-            StateFilter(
-                AdminMenuStates.SURVEYS_MENU,
-                AdminMenuStates.ANALYTICS_MENU,
-                AdminMenuStates.SETTINGS_MENU,
-            ),
-        )
-        router.callback_query.register(
-            self.handle_surveys_menu,
-            lambda c: c.data
-            in {
-                "surveys_create",
-                "surveys_my",
-                "surveys_templates",
-                "surveys_settings",
-            },
-            StateFilter(AdminMenuStates.SURVEYS_MENU),
-        )
-        router.callback_query.register(
-            self.handle_analytics_menu,
-            lambda c: c.data
-            in {
-                "analytics_export",
-                "analytics_stats",
-                "analytics_activity",
-                "analytics_ratings",
-            },
-            StateFilter(AdminMenuStates.ANALYTICS_MENU),
-        )
-        router.callback_query.register(
-            self.handle_settings_menu,
-            lambda c: c.data
-            in {
-                "settings_general",
-                "settings_notifications",
-                "settings_access",
-                "settings_testmode",
-            },
-            StateFilter(AdminMenuStates.SETTINGS_MENU),
+            self.admin_menu_callback, lambda c: c.data == "admin_menu"
         )
 
     async def unregister_handlers(self, router: Router):
         remove_plugin_handlers(self, router)
 
     def get_commands(self):
-        """Возвращает команды плагина"""
         return [types.BotCommand(command="admin", description="Админ меню")]
 
-    def get_keyboards(self):
-        """Возвращает словарь инлайн-клавиатур для различных меню"""
-
-        def btn(text: str, cb: str):
-            try:
-                return InlineKeyboardButton(text=text, callback_data=cb)
-            except TypeError:
-                # Fallback for tests where InlineKeyboardButton is mocked
-                return types.KeyboardButton(text)
-
-        def markup(rows):
-            try:
-                return InlineKeyboardMarkup(inline_keyboard=rows)
-            except TypeError:
-                # Fallback for tests where InlineKeyboardMarkup is mocked
-                return types.ReplyKeyboardMarkup(keyboard=rows)
-
-        # Главное меню
-        main = markup(
-            [
-                [
-                    btn("📊 Опросы", "admin_surveys"),
-                    btn("📈 Аналитика", "admin_analytics"),
-                ],
-                [btn("⚙ Настройки", "admin_settings")],
+    async def _show_menu(self, message: types.Message):
+        items = self.plugin_manager.get_admin_menu_items()
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text=i["text"], callback_data=i["callback"])]
+                for i in items
             ]
         )
-
-        # Меню опросов
-        surveys = markup(
-            [
-                [btn("Создать опрос", "surveys_create")],
-                [btn("Мои опросы", "surveys_my")],
-                [btn("Рассылка опроса", "surveys_send")],
-                [btn("Шаблоны вопросов", "surveys_templates")],
-                [btn("Настройки опросов", "surveys_settings")],
-                [btn("🔙 Назад", "admin_back")],
-            ]
+        await message.answer(
+            "Добро пожаловать в админ-панель.", reply_markup=keyboard
         )
-
-        # Меню аналитики
-        analytics = markup(
-            [
-                [btn("Экспорт данных", "analytics_export")],
-                [btn("Статистика опросов", "analytics_stats")],
-                [btn("Активность группы", "analytics_activity")],
-                [btn("Рейтинги", "analytics_ratings")],
-                [btn("🔙 Назад", "admin_back")],
-            ]
-        )
-
-        # Меню настроек
-        settings = markup(
-            [
-                [btn("Общие настройки", "settings_general")],
-                [btn("Настройки уведомлений", "settings_notifications")],
-                [btn("Управление доступом", "settings_access")],
-                [btn("Тестовый режим", "settings_testmode")],
-                [btn("🔙 Назад", "admin_back")],
-            ]
-        )
-
-        return {
-            "admin_main": main,
-            "admin_surveys": surveys,
-            "admin_analytics": analytics,
-            "admin_settings": settings,
-        }
 
     async def cmd_admin_menu(self, message: types.Message, state: FSMContext):
-        """Открывает меню администратора по команде"""
         logger.debug(f"{message.text} from {message.from_user.id}")
         if message.from_user.id not in self.admin_ids:
             await message.answer("У вас нет доступа к меню администратора.")
             return
-        await state.set_state(AdminMenuStates.MAIN_MENU)
-        await message.answer(
-            "Главное меню администратора:",
-            reply_markup=self.get_keyboards()["admin_main"],
-        )
+        await self._show_menu(message)
+        await state.clear()
 
     async def admin_menu_callback(
         self, callback_query: types.CallbackQuery, state: FSMContext
     ):
-        """Открывает админ меню по нажатию кнопки"""
         if callback_query.from_user.id not in self.admin_ids:
             await callback_query.answer("Нет доступа")
             return
-        await state.set_state(AdminMenuStates.MAIN_MENU)
-        await callback_query.message.answer(
-            "Главное меню администратора:",
-            reply_markup=self.get_keyboards()["admin_main"],
-        )
+        await self._show_menu(callback_query.message)
         await callback_query.answer()
-
-    async def handle_main_menu(
-        self, callback_query: types.CallbackQuery, state: FSMContext
-    ):
-        """Обрабатывает выбор пункта главного меню"""
-        data = getattr(callback_query, "data", getattr(callback_query, "text", ""))
-        if data == "admin_surveys":
-            await state.set_state(AdminMenuStates.SURVEYS_MENU)
-            await callback_query.message.edit_text(
-                "Меню управления опросами:",
-                reply_markup=self.get_keyboards()["admin_surveys"],
-            )
-        elif data == "admin_analytics":
-            await state.set_state(AdminMenuStates.ANALYTICS_MENU)
-            await callback_query.message.edit_text(
-                "Меню аналитики:",
-                reply_markup=self.get_keyboards()["admin_analytics"],
-            )
-        elif data == "admin_settings":
-            await state.set_state(AdminMenuStates.SETTINGS_MENU)
-            await callback_query.message.edit_text(
-                "Меню настроек:",
-                reply_markup=self.get_keyboards()["admin_settings"],
-            )
-        if hasattr(callback_query, "data"):
-            await callback_query.answer()
-
-    async def handle_surveys_menu(
-        self, callback_query: types.CallbackQuery, state: FSMContext
-    ):
-        """Выбор пунктов в меню опросов"""
-        data = getattr(callback_query, "data", getattr(callback_query, "text", ""))
-        message = getattr(callback_query, "message", callback_query)
-        if data in {"surveys_create", "Создать опрос"}:
-            await self.survey_plugin.cmd_create_survey(message, state)
-        elif data in {"surveys_my", "Мои опросы"}:
-            await self.survey_plugin.cmd_view_surveys(message, state)
-        elif data in {"surveys_templates", "Шаблоны вопросов"}:
-            await self.templates_plugin.cmd_list_templates(message)
-        elif data in {"surveys_settings", "Настройки опросов"}:
-            await message.answer("Функция в разработке")
-        if hasattr(callback_query, "data"):
-            await callback_query.answer()
-
-    async def handle_analytics_menu(
-        self, callback_query: types.CallbackQuery, state: FSMContext
-    ):
-        """Выбор пунктов в меню аналитики"""
-        data = getattr(callback_query, "data", getattr(callback_query, "text", ""))
-        message = getattr(callback_query, "message", callback_query)
-        if data in {"analytics_export", "Экспорт данных"}:
-            await self.export_plugin.cmd_export(message)
-        elif data in {"analytics_stats", "Статистика опросов"}:
-            await message.answer("Функция в разработке")
-        elif data in {"analytics_activity", "Активность группы"}:
-            await message.answer("Функция в разработке")
-        elif data in {"analytics_ratings", "Рейтинги"}:
-            await message.answer("Функция в разработке")
-        if hasattr(callback_query, "data"):
-            await callback_query.answer()
-
-    async def handle_settings_menu(
-        self, callback_query: types.CallbackQuery, state: FSMContext
-    ):
-        """Выбор пунктов в меню настроек"""
-        data = getattr(callback_query, "data", getattr(callback_query, "text", ""))
-        message = getattr(callback_query, "message", callback_query)
-        if data in {"settings_testmode", "Тестовый режим"}:
-            await self.test_mode_plugin.cmd_test_mode(message, state)
-        elif data in {"settings_access", "Управление доступом"}:
-            await self.roles_plugin.cmd_roles(message, state)
-        elif data in {
-            "settings_general",
-            "settings_notifications",
-            "Общие настройки",
-            "Настройки уведомлений",
-        }:
-            await message.answer("Функция в разработке")
-        if hasattr(callback_query, "data"):
-            await callback_query.answer()
-
-    async def handle_back(self, callback_query: types.CallbackQuery, state: FSMContext):
-        """Обрабатывает кнопку 'Назад'"""
-        await state.set_state(AdminMenuStates.MAIN_MENU)
-        await callback_query.message.edit_text(
-            "Главное меню администратора:",
-            reply_markup=self.get_keyboards()["admin_main"],
-        )
-        if hasattr(callback_query, "data"):
-            await callback_query.answer()
+        await state.clear()
 
 
 def load_plugin(plugin_manager: PluginManager):
-    """Загружает плагин"""
     return AdminMenuPlugin(plugin_manager=plugin_manager)
+

--- a/plugins_admin/admin_plugin.py
+++ b/plugins_admin/admin_plugin.py
@@ -13,6 +13,15 @@ from core.db_manager import get_all_groups, get_poll_by_id
 from utils.env_utils import parse_admin_ids
 from utils import remove_plugin_handlers
 
+__plugin_meta__ = {
+    "admin_menu": [
+        {"text": "\ud83d\udcec \u0420\u0430\u0441\u0441\u044b\u043b\u043a\u0430", "callback": "send_survey"},
+    ],
+    "commands": [
+        {"command": "send_survey", "description": "\u0420\u0430\u0441\u0441\u044b\u043b\u043a\u0430 \u043e\u043f\u0440\u043e\u0441\u0430"},
+    ],
+}
+
 ADMIN_IDS = parse_admin_ids()
 logger = logging.getLogger(__name__)
 logger.debug(f"Parsed ADMIN_IDS: {ADMIN_IDS}")
@@ -28,6 +37,13 @@ class AdminPlugin:
     async def register_handlers(self, router: Router):
         """Регистрирует обработчики административных команд"""
         router.message.register(self.cmd_send_survey, Command("send_survey"))
+        router.callback_query.register(
+            self._cb_send_survey,
+            lambda c: c.data == "send_survey",
+        )
+
+    async def _cb_send_survey(self, callback_query: types.CallbackQuery):
+        await self.cmd_send_survey(callback_query.message)
 
     async def unregister_handlers(self, router: Router):
         remove_plugin_handlers(self, router)

--- a/plugins_surveys/export_plugin.py
+++ b/plugins_surveys/export_plugin.py
@@ -5,8 +5,18 @@ import io
 import datetime
 import os
 
+__plugin_meta__ = {
+    "admin_menu": [
+        {"text": "\ud83d\udce6 \u042d\u043a\u0441\u043f\u043e\u0440\u0442", "callback": "export_data"},
+    ],
+    "commands": [
+        {"command": "export_data", "description": "\u042d\u043a\u0441\u043f\u043e\u0440\u0442 \u0434\u0430\u043d\u043d\u044b\u0445"},
+    ],
+}
+
 from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.filters import Command
 from utils import remove_plugin_handlers
 
 # Импорт хранилища
@@ -28,12 +38,19 @@ class ExportPlugin:
         self.description = "Экспорт данных опросов в разные форматы"
 
     async def register_handlers(self, router: Router):
+        router.message.register(self.cmd_export, Command("export_data"))
+        router.callback_query.register(
+            self._cb_export, lambda c: c.data == "export_data"
+        )
         router.callback_query.register(
             self.handle_survey_selection, lambda c: c.data.startswith("export_survey_")
         )
         router.callback_query.register(
             self.handle_format_selection, lambda c: c.data.startswith("export_format_")
         )
+
+    async def _cb_export(self, callback_query: types.CallbackQuery):
+        await self.cmd_export(callback_query.message)
 
     async def unregister_handlers(self, router: Router):
         remove_plugin_handlers(self, router)

--- a/plugins_surveys/test_mode_plugin.py
+++ b/plugins_surveys/test_mode_plugin.py
@@ -3,9 +3,19 @@ from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
+from aiogram.filters import Command
 import logging
 import copy
 from utils import remove_plugin_handlers
+
+__plugin_meta__ = {
+    "admin_menu": [
+        {"text": "\ud83e\uddea \u0422\u0435\u0441\u0442\u043e\u0432\u044b\u0439 \u0440\u0435\u0436\u0438\u043c", "callback": "test_mode"},
+    ],
+    "commands": [
+        {"command": "test_mode", "description": "\u0422\u0435\u0441\u0442\u043e\u0432\u044b\u0439 \u0440\u0435\u0436\u0438\u043c"},
+    ],
+}
 
 # Импорт хранилища
 from plugins_admin.storage_plugin import storage
@@ -25,6 +35,7 @@ class TestModePlugin:
         self.test_surveys = {}
 
     async def register_handlers(self, router: Router):
+        router.message.register(self.cmd_test_mode, Command("test_mode"))
         router.callback_query.register(
             self.handle_survey_selection, lambda c: c.data.startswith("test_survey_")
         )

--- a/plugins_surveys/view_surveys_plugin.py
+++ b/plugins_surveys/view_surveys_plugin.py
@@ -13,6 +13,15 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 import logging
 from utils import remove_plugin_handlers
 
+__plugin_meta__ = {
+    "admin_menu": [
+        {"text": "\ud83d\udcca \u041c\u043e\u0438 \u043e\u043f\u0440\u043e\u0441\u044b", "callback": "view_surveys"},
+    ],
+    "commands": [
+        {"command": "view_surveys", "description": "\u041c\u043e\u0438 \u043e\u043f\u0440\u043e\u0441\u044b"},
+    ],
+}
+
 # Используем функции из db_manager вместо отсутствующего модуля базы данных
 from core.db_manager import (
     get_all_polls,
@@ -95,6 +104,9 @@ class ViewSurveysPlugin:
         """Регистрирует все обработчики плагина"""
         router.message.register(self.cmd_view_surveys, Command("view_surveys"))
         router.callback_query.register(
+            self._cb_view_surveys, lambda c: c.data == "view_surveys"
+        )
+        router.callback_query.register(
             self.handle_survey_selection,
             lambda c: c.data.startswith("view_survey_"),
             StateFilter(ViewSurveysStates.Viewing),
@@ -109,6 +121,11 @@ class ViewSurveysPlugin:
             lambda c: c.data.startswith("survey_action_"),
             StateFilter(ViewSurveysStates.ViewingDetails),
         )
+
+    async def _cb_view_surveys(
+        self, callback_query: types.CallbackQuery, state: FSMContext
+    ):
+        await self.cmd_view_surveys(callback_query.message, state)
 
     async def unregister_handlers(self, router: Router):
         remove_plugin_handlers(self, router)


### PR DESCRIPTION
## Summary
- attach `__plugin_meta__` to plugins on load
- gather admin menu items and commands from plugin metadata
- simplify `admin_menu_plugin` to build menu dynamically
- add metadata examples to template and example plugins

## Testing
- `pip install -q -r requirements.txt` *(fails: no output)*
- `pytest -q` *(fails: 4 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c214d98832aa8d7a44f252ad18f