### PR TITLE
Add plugin meta for roles and scheduler

### DIFF
--- a/plugins_admin/roles_plugin.py
+++ b/plugins_admin/roles_plugin.py
@@ -13,6 +13,13 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import StateFilter
 from utils import remove_plugin_handlers
 
+__plugin_meta__ = {
+    "admin_menu": [{"text": "\ud83d\udd11 \u0420\u043e\u043b\u0438", "callback": "roles"}],
+    "commands": [
+        {"command": "roles", "description": "\u0423\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u0435 \u0440\u043e\u043b\u044f\u043c\u0438"},
+    ],
+}
+
 # Импортируем модуль хранилища
 try:
     from .storage_plugin import storage

--- a/plugins_admin/scheduler_plugin.py
+++ b/plugins_admin/scheduler_plugin.py
@@ -17,6 +17,13 @@ from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from utils import remove_plugin_handlers
 
+__plugin_meta__ = {
+    "admin_menu": [{"text": "\u23f0 \u041f\u043b\u0430\u043d\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u0435", "callback": "schedule"}],
+    "commands": [
+        {"command": "schedule", "description": "\u041f\u043b\u0430\u043d\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u0435 \u043e\u043f\u0440\u043e\u0441\u043e\u0432"},
+    ],
+}
+
 # Если используем собственное хранилище (storage_plugin)
 try:
     from .storage_plugin import storage


### PR DESCRIPTION
## Summary
- register menu/commands metadata for `roles_plugin`
- register menu/commands metadata for `scheduler_plugin`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f4fb18c44832a984ebc1219a3474e