### PR TITLE
Update admin menu tests for dynamic menu

### DIFF
--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -65,9 +65,7 @@ class AdminMenuPlugin:
                 for i in items
             ]
         )
-        await message.answer(
-            "Добро пожаловать в админ-панель.", reply_markup=keyboard
-        )
+        await message.answer("Добро пожаловать в админ-панель.", reply_markup=keyboard)
 
     async def cmd_admin_menu(self, message: types.Message, state: FSMContext):
         logger.debug(f"{message.text} from {message.from_user.id}")
@@ -90,4 +88,3 @@ class AdminMenuPlugin:
 
 def load_plugin(plugin_manager: PluginManager):
     return AdminMenuPlugin(plugin_manager=plugin_manager)
-

--- a/tests/test_admin_menu.py
+++ b/tests/test_admin_menu.py
@@ -24,73 +24,45 @@ class DummyState:
     async def set_state(self, state):
         self.state = state
 
+    async def clear(self):
+        self.state = None
 
-def test_admin_menu_calls(monkeypatch):
+
+def test_admin_menu_shows_items(monkeypatch):
+    monkeypatch.setenv("ADMIN_IDS", "1")
+    import aiogram.types as types
+
+    class DummyInlineButton:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+    class DummyInlineMarkup:
+        def __init__(self, *args, **kwargs):
+            self.inline_keyboard = kwargs.get("inline_keyboard", [])
+
+    monkeypatch.setattr(types, "InlineKeyboardButton", DummyInlineButton, raising=False)
+    monkeypatch.setattr(types, "InlineKeyboardMarkup", DummyInlineMarkup, raising=False)
     adm_module = importlib.reload(
         importlib.import_module("plugins_admin.admin_menu_plugin")
     )
 
-    class DummyPlugin:
-        pass
-
     class DummyPM:
         def __init__(self):
-            self.plugins = {
-                "survey_plugin": DummyPlugin(),
-                "export_plugin": DummyPlugin(),
-                "test_mode_plugin": DummyPlugin(),
-                "survey_templates_plugin": DummyPlugin(),
-                "roles_plugin": DummyPlugin(),
-            }
+            self.called = False
 
-        def get_plugin(self, name):
-            return self.plugins.get(name)
+        def get_admin_menu_items(self):
+            self.called = True
+            return [
+                {"text": "Создать опрос", "callback": "create"},
+                {"text": "Экспорт данных", "callback": "export"},
+            ]
 
     pm = DummyPM()
     plugin = adm_module.load_plugin(plugin_manager=pm)
 
-    called = {}
-
-    async def fake_create(msg, state):
-        called["create"] = msg.text
-
-    monkeypatch.setattr(
-        plugin.survey_plugin,
-        "cmd_create_survey",
-        fake_create,
-        raising=False,
-    )
-
-    async def fake_export(msg):
-        called["export"] = msg.text
-
-    monkeypatch.setattr(
-        plugin.export_plugin,
-        "cmd_export",
-        fake_export,
-        raising=False,
-    )
-
-    async def fake_test_mode(msg, state):
-        called["test_mode"] = msg.text
-
-    monkeypatch.setattr(
-        plugin.test_mode_plugin,
-        "cmd_test_mode",
-        fake_test_mode,
-        raising=False,
-    )
-
     state = DummyState()
-    msg = DummyMessage("Создать опрос")
-    asyncio.run(plugin.handle_surveys_menu(msg, state))
-    msg = DummyMessage("Экспорт данных")
-    asyncio.run(plugin.handle_analytics_menu(msg, state))
-    msg = DummyMessage("Тестовый режим")
-    asyncio.run(plugin.handle_settings_menu(msg, state))
+    msg = DummyMessage("/admin", user_id=1)
+    asyncio.run(plugin.cmd_admin_menu(msg, state))
 
-    assert called == {
-        "create": "Создать опрос",
-        "export": "Экспорт данных",
-        "test_mode": "Тестовый режим",
-    }
+    assert pm.called
+    assert "Добро пожаловать" in msg.responses[0]

--- a/tests/test_admin_menu_integration.py
+++ b/tests/test_admin_menu_integration.py
@@ -11,7 +11,7 @@ class DummyBotCommand:
 
 
 class DummyButton:
-    def __init__(self, text):
+    def __init__(self, text=None, **kwargs):
         self.text = text
 
 
@@ -152,6 +152,12 @@ def test_admin_menu_creates_survey(monkeypatch):
         aiogram.types, "ReplyKeyboardMarkup", DummyMarkup, raising=False
     )
     monkeypatch.setattr(aiogram.types, "KeyboardButton", DummyButton, raising=False)
+    monkeypatch.setattr(
+        aiogram.types, "InlineKeyboardButton", DummyButton, raising=False
+    )
+    monkeypatch.setattr(
+        aiogram.types, "InlineKeyboardMarkup", DummyMarkup, raising=False
+    )
     monkeypatch.setattr(asyncio, "create_task", lambda coro: DummyTask())
 
     for k in list(sys.modules.keys()):
@@ -250,17 +256,13 @@ def test_admin_menu_creates_survey(monkeypatch):
     survey = pm.get_plugin("survey_plugin")
 
     assert admin.plugin_manager is pm
-    assert admin.survey_plugin is survey
 
     state = DummyState()
     msg = DummyMessage("/admin")
     asyncio.run(admin.cmd_admin_menu(msg, state))
 
-    msg = DummyMessage("📊 Опросы")
-    asyncio.run(admin.handle_main_menu(msg, state))
-
     msg = DummyMessage("Создать опрос")
-    asyncio.run(admin.handle_surveys_menu(msg, state))
+    asyncio.run(survey.cmd_create_survey(msg, state))
 
     msg = DummyMessage("T")
     asyncio.run(survey.process_title(msg, state))

--- a/tests/test_admin_menu_plugins.py
+++ b/tests/test_admin_menu_plugins.py
@@ -1,5 +1,5 @@
-import importlib
 import asyncio
+import importlib
 import aiogram.types as types
 
 
@@ -19,7 +19,7 @@ class DummyMarkup:
         self.keyboard = keyboard or []
 
 
-def test_admin_menu_has_plugin_commands(monkeypatch):
+def test_admin_menu_collects_menu_items(monkeypatch):
     class DummyHandler:
         def __call__(self, *args, **kwargs):
             def decorator(func):
@@ -65,35 +65,14 @@ def test_admin_menu_has_plugin_commands(monkeypatch):
         pm_module.Dispatcher(), pm_module.Bot(), router=pm_module.Router()
     )
     asyncio.run(pm.load_plugins())
-    admin = pm.get_plugin("admin_menu_plugin")
-    keyboards = admin.get_keyboards()
-    plugin_cmds = pm.get_plugin_commands()
+    items = pm.get_admin_menu_items()
+    callbacks = {i["callback"] for i in items}
 
-    # ensure admin command is exposed
-    admin_cmds = plugin_cmds.get("admin_menu_plugin")
-    assert any(cmd.command == "admin" for cmd in admin_cmds)
-    # exclude admin command from common checks
-    plugin_cmds.pop("admin_menu_plugin", None)
+    expected = set()
+    for plugin in pm.get_all_plugins().values():
+        meta = getattr(plugin, "__plugin_meta__", None)
+        if meta and isinstance(meta.get("admin_menu"), list):
+            for entry in meta["admin_menu"]:
+                expected.add(entry["callback"])
 
-    button_texts = []
-    for kb in keyboards.values():
-        for row in kb.keyboard:
-            for btn in row:
-                button_texts.append(btn.text)
-
-    for cmds in plugin_cmds.values():
-        for cmd in cmds:
-            desc = getattr(cmd, "description", None)
-            cmd_name = getattr(cmd, "command", None)
-            assert any(t == desc or t == cmd_name for t in button_texts)
-
-    survey_texts = []
-    for row in keyboards["admin_surveys"].keyboard:
-        for btn in row:
-            survey_texts.append(btn.text)
-
-    for cmds in plugin_cmds.values():
-        for cmd in cmds:
-            desc = getattr(cmd, "description", None)
-            cmd_name = getattr(cmd, "command", None)
-            assert any(t == desc or t == cmd_name for t in survey_texts)
+    assert callbacks == expected

--- a/tests/test_admin_plugin.py
+++ b/tests/test_admin_plugin.py
@@ -19,6 +19,7 @@ class DummyHandler:
 class DummyRouter:
     def __init__(self):
         self.message = DummyHandler()
+        self.callback_query = DummyHandler()
 
 
 def test_admin_plugin_registers_handler(monkeypatch):


### PR DESCRIPTION
## Summary
- adjust admin menu tests to new dynamic design
- update integration tests accordingly
- tweak admin plugin test router

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f58d86860832aa933e2f4cecf228d