### PR TITLE
Use ReplyKeyboardMarkup for survey users

### DIFF
--- a/plugins_surveys/multiple_choice_plugin.py
+++ b/plugins_surveys/multiple_choice_plugin.py
@@ -8,8 +8,7 @@
 import logging
 
 from aiogram import Router
-from aiogram.utils.keyboard import InlineKeyboardBuilder
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import CallbackQuery, Message, ReplyKeyboardMarkup, KeyboardButton
 from core.db_manager import add_response
 from .response_mixin import ResponseMixin
 from utils import remove_plugin_handlers
@@ -35,13 +34,13 @@ class MultipleChoicePlugin(ResponseMixin):
 
     async def register_handlers(self, router: Router):
         """Регистрирует обработчики плагина (стиль aiogram 3.x)"""
-        router.callback_query.register(
+        router.message.register(
             self.process_multiple_choice_selection,
-            lambda c: c.data.startswith("multi_choice_"),
+            lambda m: m.text and m.text.startswith("multi_choice_"),
         )
-        router.callback_query.register(
+        router.message.register(
             self.process_multiple_choice_submit,
-            lambda c: c.data.startswith("multi_submit_"),
+            lambda m: m.text and m.text.startswith("multi_submit_"),
         )
         router.message.register(self.process_other_input)
 
@@ -83,29 +82,34 @@ class MultipleChoicePlugin(ResponseMixin):
 
     def render_question(self, question, survey_id):
         """Отрисовывает вопрос для ответа пользователя"""
-        builder = InlineKeyboardBuilder()
-
-        for i, option in enumerate(question["options"]):
-            builder.button(
-                text=option,
-                callback_data=f"multi_choice_{survey_id}_{question['id']}_{i}",
-            )
-
-        builder.button(
-            text="Подтвердить выбор",
-            callback_data=f"multi_submit_{survey_id}_{question['id']}",
+        keyboard = ReplyKeyboardMarkup(
+            keyboard=[
+                [
+                    KeyboardButton(
+                        text=f"multi_choice_{survey_id}_{question['id']}_{i}"
+                    )
+                ]
+                for i, _ in enumerate(question["options"])
+            ]
+            + [
+                [
+                    KeyboardButton(
+                        text=f"multi_submit_{survey_id}_{question['id']}"
+                    )
+                ]
+            ],
+            resize_keyboard=True,
+            one_time_keyboard=True,
         )
-        builder.adjust(1)
-        markup = builder.as_markup()
 
         return {
             "text": question["text"] + "\n\nВыберите один или несколько вариантов:",
-            "markup": markup,
+            "markup": keyboard,
         }
 
-    async def process_multiple_choice_selection(self, callback_query: CallbackQuery):
+    async def process_multiple_choice_selection(self, message: Message):
         """Обрабатывает выбор пользователя в вопросе с множественным выбором"""
-        parts = callback_query.data.split("_")
+        parts = message.text.split("_")
         # Примерный формат: multi_choice_<survey_id>_<question_id>_<option_index>
         survey_id = parts[2]
         question_id = parts[3]
@@ -113,16 +117,16 @@ class MultipleChoicePlugin(ResponseMixin):
 
         survey = storage.get_survey(survey_id)
         if not survey or survey["status"] != "active":
-            await callback_query.answer("Этот опрос недоступен")
+            await message.answer("Этот опрос недоступен")
             return
 
-        user_id = callback_query.from_user.id
+        user_id = message.from_user.id
 
         question = next(
             (q for q in survey["questions"] if q["id"] == question_id), None
         )
         if question and not (0 <= option_index < len(question["options"])):
-            await callback_query.answer("Неверный вариант")
+            await message.answer("Неверный вариант")
             return
         if question and question["options"][option_index].startswith("Другое"):
             state = storage.get_user_state(user_id)
@@ -131,8 +135,7 @@ class MultipleChoicePlugin(ResponseMixin):
                 user_id, f"multi_other_{survey_id}_{question_id}", True
             )
             storage.set_user_state(user_id, f"multi_{survey_id}_{question_id}", None)
-            await callback_query.message.answer("Пожалуйста, введите свой вариант:")
-            await callback_query.answer()
+            await message.answer("Пожалуйста, введите свой вариант:")
             return
 
         # Получаем или создаём выбор пользователя для данного вопроса
@@ -158,46 +161,29 @@ class MultipleChoicePlugin(ResponseMixin):
         )
         if question:
             options = question["options"]
-            builder = InlineKeyboardBuilder()
+            await message.answer("Вариант отмечен")
 
-            for i, option in enumerate(options):
-                text = f"✅ {option}" if i in selections else option
-                builder.button(
-                    text=text,
-                    callback_data=f"multi_choice_{survey_id}_{question_id}_{i}",
-                )
+        await message.answer("Выберите следующее действие или подтвердите выбор")
 
-            # Добавляем кнопку подтверждения
-            builder.button(
-                text="Подтвердить выбор",
-                callback_data=f"multi_submit_{survey_id}_{question_id}",
-            )
-            builder.adjust(1)
-            markup = builder.as_markup()
-
-            await callback_query.message.edit_reply_markup(reply_markup=markup)
-
-        await callback_query.answer()
-
-    async def process_multiple_choice_submit(self, callback_query: CallbackQuery):
+    async def process_multiple_choice_submit(self, message: Message):
         """Обрабатывает отправку ответов множественного выбора"""
-        parts = callback_query.data.split("_")
+        parts = message.text.split("_")
         # Примерный формат: multi_submit_<survey_id>_<question_id>
         survey_id = parts[2]
         question_id = parts[3]
 
         survey = storage.get_survey(survey_id)
         if not survey or survey["status"] != "active":
-            await callback_query.answer("Этот опрос недоступен")
+            await message.answer("Этот опрос недоступен")
             return
 
-        user_id = callback_query.from_user.id
+        user_id = message.from_user.id
 
         # Проверяем, не ожидается ли текстовый вариант
         if storage.get_user_state(user_id).get(
             f"multi_other_{survey_id}_{question_id}"
         ):
-            await callback_query.answer("Пожалуйста, сначала введите свой вариант")
+            await message.answer("Пожалуйста, сначала введите свой вариант")
             return
 
         # Получаем выбор пользователя
@@ -206,7 +192,7 @@ class MultipleChoicePlugin(ResponseMixin):
         selections = user_state.get(selection_key, [])
 
         if not selections:
-            await callback_query.answer("Пожалуйста, выберите хотя бы один вариант")
+            await message.answer("Пожалуйста, выберите хотя бы один вариант")
             return
 
         # Сохраняем ответ
@@ -214,7 +200,7 @@ class MultipleChoicePlugin(ResponseMixin):
             "user_id": None if survey.get("is_anonymous") else user_id,
             "question_id": question_id,
             "answer": selections,
-            "timestamp": callback_query.message.date.isoformat(),
+            "timestamp": message.date.isoformat(),
         }
 
         # Добавляем или обновляем ответ
@@ -224,18 +210,14 @@ class MultipleChoicePlugin(ResponseMixin):
             question_id,
             response["user_id"],
             ",".join(map(str, selections)),
-            callback_query.message.date,
+            message.date,
         )
         storage.save_survey(survey_id, survey)
 
         # Очищаем выбор пользователя
         storage.set_user_state(user_id, selection_key, None)
 
-        await callback_query.answer("Ваши ответы записаны!")
-
-        # Обновляем сообщение, что ответ принят
-        old_text = callback_query.message.text or ""
-        await callback_query.message.edit_text(f"{old_text}\n\n✅ Ваш ответ принят!")
+        await message.answer("Ваши ответы записаны!")
 
     async def process_other_input(self, message: Message):
         user_id = message.from_user.id

--- a/plugins_surveys/single_choice_plugin.py
+++ b/plugins_surveys/single_choice_plugin.py
@@ -3,7 +3,7 @@
 """
 
 from aiogram import Router, types
-from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from core.db_manager import add_response
 from .response_mixin import ResponseMixin
 from utils import remove_plugin_handlers
@@ -28,9 +28,9 @@ class SingleChoicePlugin(ResponseMixin):
         self.description = "Тип вопроса - одиночный выбор"
 
     async def register_handlers(self, router: Router):
-        router.callback_query.register(
+        router.message.register(
             self.process_single_choice_selection,
-            lambda c: c.data.startswith("single_choice_"),
+            lambda m: m.text and m.text.startswith("single_choice_"),
         )
         router.message.register(self.process_other_input)
 
@@ -67,47 +67,50 @@ class SingleChoicePlugin(ResponseMixin):
         }
 
     def render_question(self, question, survey_id):
-        builder = InlineKeyboardBuilder()
-        for i, option in enumerate(question["options"]):
-            builder.button(
-                text=option,
-                callback_data=f"single_choice_{survey_id}_{question['id']}_{i}",
-            )
-        builder.adjust(1)
-        markup = builder.as_markup()
-        return {"text": question["text"], "markup": markup}
+        keyboard = ReplyKeyboardMarkup(
+            keyboard=[
+                [
+                    KeyboardButton(
+                        text=f"single_choice_{survey_id}_{question['id']}_{i}"
+                    )
+                ]
+                for i, _ in enumerate(question["options"])
+            ],
+            resize_keyboard=True,
+            one_time_keyboard=True,
+        )
+        return {"text": question["text"], "markup": keyboard}
 
     async def process_single_choice_selection(
-        self, callback_query: types.CallbackQuery
+        self, message: types.Message
     ):
-        parts = callback_query.data.split("_")
+        parts = message.text.split("_")
         survey_id = parts[2]
         question_id = parts[3]
         option_index = int(parts[4])
         survey = storage.get_survey(survey_id)
         if not survey or survey["status"] != "active":
-            await callback_query.answer("Этот опрос недоступен")
+            await message.answer("Этот опрос недоступен")
             return
-        user_id = callback_query.from_user.id
+        user_id = message.from_user.id
         question = next(
             (q for q in survey["questions"] if q["id"] == question_id), None
         )
         if question and not (0 <= option_index < len(question["options"])):
-            await callback_query.answer("Неверный вариант")
+            await message.answer("Неверный вариант")
             return
         if question and question["options"][option_index].startswith("Другое"):
             state = storage.get_user_state(user_id)
             state["single_other"] = {"survey_id": survey_id, "question_id": question_id}
             storage.set_user_state(user_id, "single_other", state["single_other"])
-            await callback_query.message.answer("Пожалуйста, введите свой вариант:")
-            await callback_query.answer()
+            await message.answer("Пожалуйста, введите свой вариант:")
             return
 
         response = {
             "user_id": None if survey["is_anonymous"] else user_id,
             "question_id": question_id,
             "answer": option_index,
-            "timestamp": callback_query.message.date.isoformat(),
+            "timestamp": message.date.isoformat(),
         }
         self._add_or_update_response(survey, user_id, question_id, response)
         add_response(
@@ -115,22 +118,11 @@ class SingleChoicePlugin(ResponseMixin):
             question_id,
             response["user_id"],
             option_index,
-            callback_query.message.date,
+            message.date,
         )
         storage.save_survey(survey_id, survey)
         if question:
-            options = question["options"]
-            builder = InlineKeyboardBuilder()
-            for i, option in enumerate(options):
-                text = f"✅ {option}" if i == option_index else option
-                builder.button(
-                    text=text,
-                    callback_data=f"single_choice_{survey_id}_{question_id}_{i}",
-                )
-            builder.adjust(1)
-            markup = builder.as_markup()
-            await callback_query.message.edit_reply_markup(reply_markup=markup)
-        await callback_query.answer("Ваш ответ записан!")
+            await message.answer("Ваш ответ записан!")
 
     async def process_other_input(self, message: types.Message):
         user_id = message.from_user.id

--- a/plugins_surveys/text_answer_plugin.py
+++ b/plugins_surveys/text_answer_plugin.py
@@ -6,7 +6,7 @@
 """
 
 from aiogram import Router, types
-from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.filters import StateFilter  # Добавляем фильтр состояния
@@ -42,8 +42,8 @@ class TextAnswerPlugin(ResponseMixin):
 
     async def register_handlers(self, router: Router):
         """Регистрирует все обработчики плагина"""
-        router.callback_query.register(
-            self.start_text_answer, lambda c: c.data.startswith("text_answer_")
+        router.message.register(
+            self.start_text_answer, lambda m: m.text and m.text.startswith("text_answer_")
         )
         router.message.register(
             self.process_text_answer,
@@ -82,35 +82,34 @@ class TextAnswerPlugin(ResponseMixin):
 
     def render_question(self, question, survey_id):
         """Отображает вопрос для ответа"""
-        builder = InlineKeyboardBuilder()
-        builder.button(
-            text="Ответить", callback_data=f"text_answer_{survey_id}_{question['id']}"
+        keyboard = ReplyKeyboardMarkup(
+            keyboard=[[KeyboardButton(text=f"text_answer_{survey_id}_{question['id']}")]],
+            resize_keyboard=True,
+            one_time_keyboard=True,
         )
-        markup = builder.as_markup()
 
-        return {"text": question["text"], "markup": markup}
+        return {"text": question["text"], "markup": keyboard}
 
     async def start_text_answer(
-        self, callback_query: types.CallbackQuery, state: FSMContext
+        self, message: types.Message, state: FSMContext
     ):
         """Запускает процесс ввода текстового ответа"""
-        parts = callback_query.data.split("_")
+        parts = message.text.split("_")
         survey_id = parts[2]
         question_id = parts[3]
 
         survey = storage.get_survey(survey_id)
         if not survey or survey["status"] != "active":
-            await callback_query.answer("Этот опрос недоступен")
+            await message.answer("Этот опрос недоступен")
             return
 
         # Сохраняем информацию о вопросе в состоянии
         await state.update_data(survey_id=survey_id, question_id=question_id)
 
         await state.set_state(TextAnswerStates.WAITING_FOR_ANSWER)
-        await callback_query.message.reply(
+        await message.answer(
             "Пожалуйста, введите ваш ответ на вопрос. Отправьте сообщение с текстом:"
         )
-        await callback_query.answer()
 
     async def process_text_answer(self, message: types.Message, state: FSMContext):
         """Обрабатывает введённый текстовый ответ"""

--- a/tests/test_invalid_option_index.py
+++ b/tests/test_invalid_option_index.py
@@ -43,15 +43,6 @@ class DummyMessage:
         pass
 
 
-class DummyCallback:
-    def __init__(self, data, user_id=1):
-        self.data = data
-        self.from_user = type("U", (), {"id": user_id})
-        self.message = DummyMessage("")
-        self.answered = []
-
-    async def answer(self, text=None, **kw):
-        self.answered.append(text)
 
 
 def setup_single(monkeypatch):
@@ -88,9 +79,9 @@ def test_single_invalid_index(monkeypatch):
         "responses": [],
     }
     storage.save_survey("s1", survey)
-    cb = DummyCallback("single_choice_s1_q1_5")
-    asyncio.run(plugin.process_single_choice_selection(cb))
-    assert cb.answered and cb.answered[0] == "Неверный вариант"
+    msg_cmd = DummyMessage("single_choice_s1_q1_5")
+    asyncio.run(plugin.process_single_choice_selection(msg_cmd))
+    assert msg_cmd.sent and msg_cmd.sent[0] == "Неверный вариант"
     assert not survey["responses"]
 
 
@@ -106,7 +97,7 @@ def test_multi_invalid_index(monkeypatch):
         "responses": [],
     }
     storage.save_survey("s1", survey)
-    cb = DummyCallback("multi_choice_s1_q1_3")
-    asyncio.run(plugin.process_multiple_choice_selection(cb))
-    assert cb.answered and cb.answered[0] == "Неверный вариант"
+    msg_cmd = DummyMessage("multi_choice_s1_q1_3")
+    asyncio.run(plugin.process_multiple_choice_selection(msg_cmd))
+    assert msg_cmd.sent and msg_cmd.sent[0] == "Неверный вариант"
     assert not survey["responses"]

--- a/tests/test_other_option.py
+++ b/tests/test_other_option.py
@@ -43,14 +43,6 @@ class DummyMessage:
         pass
 
 
-class DummyCallback:
-    def __init__(self, data, user_id=1):
-        self.data = data
-        self.from_user = type("U", (), {"id": user_id})
-        self.message = DummyMessage("")
-
-    async def answer(self, *a, **kw):
-        pass
 
 
 def setup_single(monkeypatch):
@@ -94,8 +86,8 @@ def test_single_other(monkeypatch):
         "responses": [],
     }
     storage.save_survey("s1", survey)
-    cb = DummyCallback("single_choice_s1_q1_1")
-    asyncio.run(plugin.process_single_choice_selection(cb))
+    msg_cmd = DummyMessage("single_choice_s1_q1_1")
+    asyncio.run(plugin.process_single_choice_selection(msg_cmd))
     assert storage.get_user_state(1).get("single_other")
     msg = DummyMessage("X")
     asyncio.run(plugin.process_other_input(msg))


### PR DESCRIPTION
## Summary
- update single-choice, multiple-choice and text-answer survey plugins to use `ReplyKeyboardMarkup`
- handle selections via messages instead of callbacks
- update tests for new reply keyboard behavior

## Testing
- `pip install -q -r requirements.txt` *(fails: building wheel for aiohttp)*
- `pip install aiohttp==3.9.5`
- `pip install aiogram==3.0.0b7 --no-deps`
- `pip install aiofiles==23.1.0 async_timeout==4.0.3 charset_normalizer==3.4.2 magic_filter==1.0.12 pydantic==1.10.22 certifi==2025.7.14`
- `pip install pandas openpyxl packaging SQLAlchemy alembic python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808b9f2110832a8c18735bac7548e0