### PR TITLE
Improve survey pinning logic

### DIFF
--- a/plugins_admin/admin_plugin.py
+++ b/plugins_admin/admin_plugin.py
@@ -11,7 +11,7 @@ from aiogram.filters import Command
 
 from core.db_manager import get_all_groups, get_poll_by_id
 from utils.env_utils import parse_admin_ids
-from utils import remove_plugin_handlers
+from utils import remove_plugin_handlers, try_pin_message
 
 __plugin_meta__ = {
     "admin_menu": [
@@ -82,7 +82,9 @@ class AdminPlugin:
     def on_plugin_unload(self):
         logger.info("Плагин администратора выгружен")
 
-    async def send_survey_to_users(self, poll_id: int, bot: Bot):
+    async def send_survey_to_users(
+        self, poll_id: int, bot: Bot, *, skip_pin: bool = False
+    ):
         poll = get_poll_by_id(poll_id)
         if not poll:
             logger.error(f"Опрос с ID {poll_id} не найден.")
@@ -95,11 +97,15 @@ class AdminPlugin:
         for group in groups:
             group_id = group["group_id"]
             try:
-                await bot.send_message(
+                msg = await bot.send_message(
                     chat_id=group_id,
                     text=f"Внимание! Новый опрос '{poll_name}': {survey_link}",
                 )
-                logger.info(f"Опрос '{poll_name}' отправлен в группу {group_id}.")
+                if not skip_pin:
+                    await try_pin_message(bot, group_id, msg.message_id)
+                logger.info(
+                    f"Опрос '{poll_name}' отправлен в группу {group_id}."
+                )
             except Exception as e:
                 logger.error(f"Не удалось отправить опрос в группу {group_id}: {e}")
 

--- a/plugins_surveys/scheduler_plugin.py
+++ b/plugins_surveys/scheduler_plugin.py
@@ -15,7 +15,7 @@ from aiogram import Router, types, Bot
 from aiogram.fsm.context import FSMContext  # <-- Вместо dispatcher.FSMContext
 from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.filters.state
 from aiogram.utils.keyboard import InlineKeyboardBuilder
-from utils import remove_plugin_handlers
+from utils import remove_plugin_handlers, try_pin_message
 
 __plugin_meta__ = {
     "admin_menu": [{"text": "\u23f0 \u041f\u043b\u0430\u043d\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u0435", "callback": "schedule"}],
@@ -489,20 +489,7 @@ class SchedulerPlugin:
 
     async def _try_pin(self, chat_id: int, message_id: int):
         """Пытается закрепить сообщение, если у бота есть такие права"""
-        try:
-            me = await self.bot.get_me()
-            member = await self.bot.get_chat_member(chat_id, me.id)
-            can_pin = (
-                getattr(member, "can_pin_messages", False) or member.status == "creator"
-            )
-            if can_pin:
-                await self.bot.pin_chat_message(
-                    chat_id=chat_id, message_id=message_id, disable_notification=False
-                )
-            else:
-                logger.warning(f"У бота нет прав закреплять сообщения в чате {chat_id}")
-        except Exception as e:
-            logger.error(f"Не удалось закрепить сообщение в чате {chat_id}: {e}")
+        await try_pin_message(self.bot, chat_id, message_id)
 
     async def cmd_list_scheduled(self, message: types.Message):
         """Обработка команды /scheduled — список запланированных опросов для данного пользователя"""

--- a/tests/test_admin_send_survey.py
+++ b/tests/test_admin_send_survey.py
@@ -1,0 +1,59 @@
+import importlib
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+        self.pinned = []
+        self.id = 99
+        self.username = "testbot"
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.sent.append((chat_id, text))
+        class Msg:
+            def __init__(self, mid):
+                self.message_id = mid
+        return Msg(len(self.sent))
+
+    async def get_me(self):
+        class Me:
+            def __init__(self, id_, username):
+                self.id = id_
+                self.username = username
+        return Me(self.id, self.username)
+
+    async def get_chat_member(self, chat_id, user_id):
+        class Member:
+            status = "administrator"
+            can_pin_messages = True
+        return Member()
+
+    async def pin_chat_message(self, chat_id, message_id, **kwargs):
+        self.pinned.append((chat_id, message_id, kwargs))
+
+
+def setup_plugin(monkeypatch):
+    module = importlib.reload(importlib.import_module("plugins_admin.admin_plugin"))
+    monkeypatch.setattr(module, "get_poll_by_id", lambda pid: {"name": "S"})
+    monkeypatch.setattr(module, "get_all_groups", lambda: [{"group_id": 1}])
+    return module.load_plugin()
+
+
+def test_send_survey_pins(monkeypatch):
+    plugin = setup_plugin(monkeypatch)
+    bot = DummyBot()
+    asyncio.run(plugin.send_survey_to_users(1, bot))
+    assert bot.pinned
+    assert bot.pinned[0][2].get("disable_notification") is False
+
+
+def test_send_survey_skip_pin(monkeypatch):
+    plugin = setup_plugin(monkeypatch)
+    bot = DummyBot()
+    asyncio.run(plugin.send_survey_to_users(1, bot, skip_pin=True))
+    assert not bot.pinned

--- a/tests/test_scheduler_restore.py
+++ b/tests/test_scheduler_restore.py
@@ -53,7 +53,7 @@ class DummyBot:
         return Member()
 
     async def pin_chat_message(self, chat_id, message_id, **kwargs):
-        self.pinned.append((chat_id, message_id))
+        self.pinned.append((chat_id, message_id, kwargs))
 
 
 def test_restore_scheduled(monkeypatch):
@@ -139,3 +139,4 @@ def test_scheduled_send(monkeypatch):
 
     assert bot.sent
     assert bot.pinned
+    assert bot.pinned[0][2].get("disable_notification") is False

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
-from .aiogram_utils import remove_plugin_handlers
+from .aiogram_utils import remove_plugin_handlers, try_pin_message
 
-__all__ = ["remove_plugin_handlers"]
+__all__ = ["remove_plugin_handlers", "try_pin_message"]

--- a/utils/aiogram_utils.py
+++ b/utils/aiogram_utils.py
@@ -1,4 +1,5 @@
-from aiogram import Router
+from aiogram import Router, Bot
+import logging
 
 
 def remove_plugin_handlers(plugin, router: Router) -> None:
@@ -13,3 +14,22 @@ def remove_plugin_handlers(plugin, router: Router) -> None:
             for h in handlers
             if getattr(getattr(h, "callback", h), "__self__", None) is not plugin
         ]
+
+
+logger = logging.getLogger(__name__)
+
+
+async def try_pin_message(bot: Bot, chat_id: int, message_id: int) -> None:
+    """Attempt to pin a message if the bot has permission."""
+    try:
+        me = await bot.get_me()
+        member = await bot.get_chat_member(chat_id, me.id)
+        can_pin = getattr(member, "can_pin_messages", False) or member.status == "creator"
+        if can_pin:
+            await bot.pin_chat_message(
+                chat_id=chat_id, message_id=message_id, disable_notification=False
+            )
+        else:
+            logger.warning(f"У бота нет прав закреплять сообщения в чате {chat_id}")
+    except Exception as e:
+        logger.error(f"Не удалось закрепить сообщение в чате {chat_id}: {e}")


### PR DESCRIPTION
## Summary
- add `try_pin_message` utility for pinning chat messages
- use `try_pin_message` in scheduler and admin plugins
- skip pinning for primary survey if requested
- test admin survey pinning
- record pin kwargs in scheduler tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68832dcf5004832a9598975a90dcb01a