### PR TITLE
Add command filters for schedule and roles plugins

### DIFF
--- a/plugins_admin/roles_plugin.py
+++ b/plugins_admin/roles_plugin.py
@@ -10,7 +10,7 @@ from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.filters import StateFilter
+from aiogram.filters import Command, StateFilter
 from utils import remove_plugin_handlers
 
 __plugin_meta__ = {
@@ -83,6 +83,7 @@ class RolesPlugin:
     async def register_handlers(self, router: Router):
         """Регистрирует все обработчики для этого плагина"""
 
+        router.message.register(self.cmd_roles, Command("roles"))
         router.message.register(
             self.cmd_roles, lambda msg: msg.text == "\ud83d\udd11 \u0420\u043e\u043b\u0438"
         )

--- a/plugins_surveys/scheduler_plugin.py
+++ b/plugins_surveys/scheduler_plugin.py
@@ -15,6 +15,7 @@ from aiogram import Router, types, Bot
 from aiogram.fsm.context import FSMContext  # <-- Вместо dispatcher.FSMContext
 from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.filters.state
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.filters import Command
 from utils import remove_plugin_handlers, try_pin_message
 
 __plugin_meta__ = {
@@ -62,6 +63,7 @@ class SchedulerPlugin:
         Регистрируем хендлеры (обработчики) в стиле aiogram 3.x
         """
 
+        router.message.register(self.cmd_schedule, Command("schedule"))
         router.message.register(
             self.cmd_schedule, lambda msg: msg.text == "\u23f0 \u041f\u043b\u0430\u043d\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u0435"
         )
@@ -93,6 +95,8 @@ class SchedulerPlugin:
             lambda c: c.data.startswith("schedule_confirm_"),
             SchedulerStates.CONFIRMING,
         )
+
+        router.message.register(self.cmd_list_scheduled, Command("scheduled"))
 
         # Команда /scheduled (без конкретного состояния)
         # список также вызывается через меню


### PR DESCRIPTION
## Summary
- hook `/schedule` and `/scheduled` commands in scheduler plugin
- hook `/roles` command in roles plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833a92b5e4832a86142b0a03f967d4