### PR TITLE
Log admin menu items

### DIFF
--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -59,6 +59,7 @@ class AdminMenuPlugin:
 
     async def _show_menu(self, message: types.Message):
         items = self.plugin_manager.get_admin_menu_items()
+        logger.debug("Admin menu items: %s", items)
         keyboard = ReplyKeyboardMarkup(
             keyboard=[[KeyboardButton(text=i["text"])] for i in items],
             resize_keyboard=True,


### PR DESCRIPTION
## Summary
- add a debug log for admin menu items in `_show_menu`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838f6e8864832aa565a886610c0b20