### PR TITLE
Implement get_commands for admin plugins

### DIFF
--- a/plugins_admin/access_control_plugin.py
+++ b/plugins_admin/access_control_plugin.py
@@ -1,6 +1,6 @@
 """Access control plugin skeleton."""
 
-from aiogram import Router
+from aiogram import Router, types
 
 __plugin_meta__ = {
     "admin_menu": [],
@@ -18,6 +18,24 @@ class AccessControlPlugin:
     async def register_handlers(self, router: Router):
         """Register plugin handlers."""
         pass
+
+    def get_commands(self):
+        """Return bot commands defined in meta-data."""
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - fallback for tests
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
+        return []
 
 
 def load_plugin():

--- a/plugins_admin/analytics_plugin.py
+++ b/plugins_admin/analytics_plugin.py
@@ -1,6 +1,6 @@
 """Basic analytics plugin skeleton."""
 
-from aiogram import Router
+from aiogram import Router, types
 
 __plugin_meta__ = {
     "admin_menu": [],
@@ -19,6 +19,24 @@ class AnalyticsPlugin:
         """Register plugin handlers."""
         # Handlers would be registered here
         pass
+
+    def get_commands(self):
+        """Return bot commands from plugin meta-data."""
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - tests may patch
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
+        return []
 
 
 def load_plugin():

--- a/plugins_admin/captcha_plugin.py
+++ b/plugins_admin/captcha_plugin.py
@@ -11,7 +11,7 @@ import logging
 import random
 import string
 
-from aiogram import Dispatcher, Router
+from aiogram import Dispatcher, Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import ChatMemberUpdated, Message, CallbackQuery, ChatPermissions
@@ -128,6 +128,20 @@ class CaptchaPlugin:
         remove_plugin_handlers(self, router)
 
     def get_commands(self):
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - tests may patch
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
         return []
 
     def is_access_granted(self, user_id: int) -> bool:

--- a/plugins_admin/group_event_plugin.py
+++ b/plugins_admin/group_event_plugin.py
@@ -7,7 +7,7 @@ import logging
 import asyncio
 from aiogram.types import ChatPermissions, ChatMemberUpdated, Message
 from aiogram.client.bot import Bot
-from aiogram import Router
+from aiogram import Router, types
 from aiogram.filters import ChatMemberUpdatedFilter
 from core.db_manager import (
     is_user_pending,
@@ -176,6 +176,20 @@ class GroupEventPlugin:
         await unrestrict_user_if_needed(message.bot, message.from_user.id)
 
     def get_commands(self):
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - tests may patch
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
         return []
 
     def on_plugin_load(self):

--- a/plugins_admin/notify_plugin.py
+++ b/plugins_admin/notify_plugin.py
@@ -1,6 +1,6 @@
 """Notification plugin skeleton."""
 
-from aiogram import Router
+from aiogram import Router, types
 
 __plugin_meta__ = {
     "admin_menu": [],
@@ -18,6 +18,23 @@ class NotifyPlugin:
     async def register_handlers(self, router: Router):
         """Register plugin handlers."""
         pass
+
+    def get_commands(self):
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - tests may patch
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
+        return []
 
 
 def load_plugin():

--- a/plugins_admin/plugin_list_plugin.py
+++ b/plugins_admin/plugin_list_plugin.py
@@ -34,6 +34,23 @@ class PluginListPlugin:
         router.message.register(self.cmd_plugins, Command("plugins"))
         router.callback_query.register(self.cb_plugins, lambda c: c.data == "plugins")
 
+    def get_commands(self):
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - tests may patch
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
+        return []
+
     async def unregister_handlers(self, router: Router):
         remove_plugin_handlers(self, router)
 

--- a/plugins_admin/roles_plugin.py
+++ b/plugins_admin/roles_plugin.py
@@ -125,6 +125,20 @@ class RolesPlugin:
 
     def get_commands(self):
         """Возвращает список команд, предоставляемых плагином"""
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
         return []
 
     def has_permission(self, user_id, permission):

--- a/plugins_admin/storage_plugin.py
+++ b/plugins_admin/storage_plugin.py
@@ -7,7 +7,7 @@ import json
 import os
 import logging
 from typing import Dict, Any, Optional
-from aiogram import Router
+from aiogram import Router, types
 from utils import remove_plugin_handlers
 from utils.env_utils import parse_admin_ids
 
@@ -131,6 +131,20 @@ class StoragePlugin:
 
     def get_commands(self):
         """Команды для этого плагина отсутствуют"""
+        meta = getattr(self, "__plugin_meta__", None)
+        try:
+            BotCommandCls = types.BotCommand
+        except AttributeError:  # pragma: no cover - tests may patch
+            from aiogram.types import BotCommand as BotCommandCls
+        if meta and isinstance(meta.get("commands"), list):
+            return [
+                BotCommandCls(
+                    command=c.get("command"),
+                    description=c.get("description", ""),
+                )
+                for c in meta["commands"]
+                if isinstance(c, dict) and "command" in c
+            ]
         return []
 
     def on_plugin_load(self):


### PR DESCRIPTION
## Summary
- implement `get_commands` for admin plugins
- import `types` to create `BotCommand` objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883982be40c832a9f779bc89b40f30a