### PR TITLE
Add permission-based admin menu filtering

### DIFF
--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -265,9 +265,17 @@ class PluginManager:
     def get_all_plugins(self) -> Dict[str, Any]:
         return self.plugins
 
-    def get_admin_menu_items(self) -> List[Dict[str, str]]:
-        """Собирает пункты административного меню из мета-данных плагинов."""
+    def get_admin_menu_items(self, user_id: int | None = None) -> List[Dict[str, str]]:
+        """Собирает пункты административного меню из мета-данных плагинов.
+
+        Если указан ``user_id``, то элементы меню фильтруются в соответствии с
+        разрешениями пользователя с помощью плагина ``roles_plugin``. В каждом
+        элементе ``admin_menu`` может быть указан необязательный ключ
+        ``permission``. Если он присутствует, то соответствующий пункт меню будет
+        показан только если у пользователя есть данное разрешение.
+        """
         items: List[Dict[str, str]] = []
+        roles = self.plugins.get("roles_plugin") if user_id is not None else None
         for name, plugin in self.plugins.items():
             meta = getattr(plugin, "__plugin_meta__", None)
             if not meta:
@@ -279,16 +287,35 @@ class PluginManager:
                 logger.warning(f"admin_menu в плагине {name} должен быть списком")
                 continue
             for item in menu:
-                if (
+                if not (
                     isinstance(item, dict)
                     and isinstance(item.get("text"), str)
                     and isinstance(item.get("callback"), str)
                 ):
-                    items.append({"text": item["text"], "callback": item["callback"]})
-                else:
                     logger.warning(
                         f"Неверный элемент admin_menu в плагине {name}: {item}"
                     )
+                    continue
+
+                permission = item.get("permission")
+                if (
+                    roles is not None
+                    and permission is not None
+                    and hasattr(roles, "has_permission")
+                ):
+                    try:
+                        if not roles.has_permission(user_id, permission):
+                            continue
+                    except Exception as e:  # pragma: no cover - unexpected errors
+                        logger.warning(
+                            "Ошибка проверки разрешения %s для пользователя %s: %s",
+                            permission,
+                            user_id,
+                            e,
+                        )
+                        continue
+
+                items.append({"text": item["text"], "callback": item["callback"]})
         return items
 
     def get_all_commands(self) -> List[BotCommand]:

--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -58,7 +58,7 @@ class AdminMenuPlugin:
         return [types.BotCommand(command="admin", description="Админ меню")]
 
     async def _show_menu(self, message: types.Message):
-        items = self.plugin_manager.get_admin_menu_items()
+        items = self.plugin_manager.get_admin_menu_items(message.from_user.id)
         logger.debug("Admin menu items: %s", items)
         keyboard = ReplyKeyboardMarkup(
             keyboard=[[KeyboardButton(text=i["text"])] for i in items],

--- a/tests/test_admin_menu.py
+++ b/tests/test_admin_menu.py
@@ -50,8 +50,8 @@ def test_admin_menu_shows_items(monkeypatch):
         def __init__(self):
             self.called = False
 
-        def get_admin_menu_items(self):
-            self.called = True
+        def get_admin_menu_items(self, user_id=None):
+            self.called = user_id
             return [
                 {"text": "Создать опрос", "callback": "create"},
                 {"text": "Экспорт данных", "callback": "export"},
@@ -64,5 +64,5 @@ def test_admin_menu_shows_items(monkeypatch):
     msg = DummyMessage("/admin", user_id=1)
     asyncio.run(plugin.cmd_admin_menu(msg, state))
 
-    assert pm.called
+    assert pm.called == 1
     assert "Добро пожаловать" in msg.responses[0]

--- a/tests/test_admin_menu_permissions.py
+++ b/tests/test_admin_menu_permissions.py
@@ -1,0 +1,38 @@
+import plugin_manager as pm_module
+import aiogram
+
+class DummyRoles:
+    def has_permission(self, user_id, perm):
+        return user_id == 1 and perm == "allow"
+
+class DummyPlugin:
+    __plugin_meta__ = {
+        "admin_menu": [
+            {"text": "A", "callback": "a", "permission": "allow"},
+            {"text": "B", "callback": "b", "permission": "deny"},
+            {"text": "C", "callback": "c"},
+        ]
+    }
+    async def register_handlers(self, router):
+        pass
+
+
+def test_admin_menu_respects_permissions():
+    pm = pm_module.PluginManager(pm_module.Dispatcher(), pm_module.Bot(), router=pm_module.Router())
+    pm.plugins = {"roles_plugin": DummyRoles(), "dummy": DummyPlugin()}
+
+    items_user1 = pm.get_admin_menu_items(user_id=1)
+    items_user2 = pm.get_admin_menu_items(user_id=2)
+    items_none = pm.get_admin_menu_items()
+
+    assert {"text": "A", "callback": "a"} in items_user1
+    assert {"text": "B", "callback": "b"} not in items_user1
+    assert {"text": "C", "callback": "c"} in items_user1
+
+    assert {"text": "A", "callback": "a"} not in items_user2
+    assert {"text": "B", "callback": "b"} not in items_user2
+    assert {"text": "C", "callback": "c"} in items_user2
+
+    assert {"text": "A", "callback": "a"} in items_none
+    assert {"text": "B", "callback": "b"} in items_none
+    assert {"text": "C", "callback": "c"} in items_none

--- a/tests/test_admin_menu_plugins.py
+++ b/tests/test_admin_menu_plugins.py
@@ -65,7 +65,7 @@ def test_admin_menu_collects_menu_items(monkeypatch):
         pm_module.Dispatcher(), pm_module.Bot(), router=pm_module.Router()
     )
     asyncio.run(pm.load_plugins())
-    items = pm.get_admin_menu_items()
+    items = pm.get_admin_menu_items(user_id=1)
     callbacks = {i["callback"] for i in items}
 
     expected = set()


### PR DESCRIPTION
## Summary
- filter admin menu entries by permission using roles plugin
- pass user id to admin menu manager
- test permission filtering
- update existing admin menu tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688520e1a5ec832a8ea622faa5d1618d