### PR TITLE
Enable '🔌 Плагины' button for plugin list

### DIFF
--- a/plugins_admin/plugin_list_plugin.py
+++ b/plugins_admin/plugin_list_plugin.py
@@ -32,6 +32,9 @@ class PluginListPlugin:
 
     async def register_handlers(self, router: Router):
         router.message.register(self.cmd_plugins, Command("plugins"))
+        router.message.register(
+            self.cmd_plugins, lambda m: m.text == "\ud83d\udd0c \u041f\u043b\u0430\u0433\u0438\u043d\u044b"
+        )
         router.callback_query.register(self.cb_plugins, lambda c: c.data == "plugins")
 
     def get_commands(self):

--- a/tests/test_plugin_list_plugin.py
+++ b/tests/test_plugin_list_plugin.py
@@ -1,0 +1,57 @@
+import asyncio
+import importlib
+
+
+class DummyMessage:
+    def __init__(self, text):
+        self.text = text
+        self.responses = []
+
+    async def answer(self, text, **kwargs):
+        self.responses.append(text)
+
+
+class DummyHandler:
+    def __init__(self):
+        self.handlers = []
+
+    def register(self, handler, *args, **kwargs):
+        self.handlers.append(handler)
+
+    __call__ = register
+
+
+class DummyRouter:
+    def __init__(self):
+        self.message = DummyHandler()
+        self.callback_query = DummyHandler()
+
+
+class DummyPM:
+    def __init__(self, names=None):
+        self.names = names or []
+
+    def list_plugin_names(self):
+        return self.names
+
+
+def test_plugin_list_registers_handlers():
+    module = importlib.reload(importlib.import_module("plugins_admin.plugin_list_plugin"))
+    pm = DummyPM()
+    plugin = module.load_plugin(plugin_manager=pm)
+    router = DummyRouter()
+    asyncio.run(plugin.register_handlers(router))
+
+    assert plugin.cmd_plugins in router.message.handlers
+    assert plugin.cb_plugins in router.callback_query.handlers
+
+
+def test_cmd_plugins_button_text():
+    module = importlib.reload(importlib.import_module("plugins_admin.plugin_list_plugin"))
+    pm = DummyPM(["one", "two"])
+    plugin = module.load_plugin(plugin_manager=pm)
+    msg = DummyMessage("🔌 Плагины")
+    asyncio.run(plugin.cmd_plugins(msg))
+
+    assert msg.responses
+    assert msg.responses[0] == "one\ntwo"


### PR DESCRIPTION
## Summary
- trigger plugin list command when user taps the "Плагины" button
- test registration of PluginListPlugin handlers
- test listing plugins when the "Плагины" button text is sent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852c40f4ec832ab45cec0aff812bcc