### PR TITLE
Add fallback text filters for menu commands

### DIFF
--- a/plugins_admin/admin_menu_plugin.py
+++ b/plugins_admin/admin_menu_plugin.py
@@ -22,6 +22,11 @@ from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram.filters import Command
+try:
+    from aiogram.filters import Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 
 from utils.env_utils import parse_admin_ids
 from utils import remove_plugin_handlers
@@ -48,7 +53,7 @@ class AdminMenuPlugin:
     async def register_handlers(self, router: Router):
         router.message.register(self.cmd_admin_menu, Command("admin"))
         router.message.register(
-            self.cmd_admin_menu, lambda m: m.text == "Админ меню"
+            self.cmd_admin_menu, Text("Админ меню")
         )
 
     async def unregister_handlers(self, router: Router):

--- a/plugins_admin/admin_plugin.py
+++ b/plugins_admin/admin_plugin.py
@@ -7,7 +7,13 @@ Admin Plugin для Telegram бота.
 import logging
 from aiogram.client.bot import Bot
 from aiogram import Router, types
-from aiogram.filters import Command
+try:
+    from aiogram.filters import Command, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 
 from core.db_manager import get_all_groups, get_poll_by_id
 from utils.env_utils import parse_admin_ids
@@ -38,7 +44,8 @@ class AdminPlugin:
         """Регистрирует обработчики административных команд"""
         router.message.register(self.cmd_send_survey, Command("send_survey"))
         router.message.register(
-            self.cmd_send_survey, lambda msg: msg.text == "\ud83d\udcec \u0420\u0430\u0441\u0441\u044b\u043b\u043a\u0430"
+            self.cmd_send_survey,
+            Text("\ud83d\udcec \u0420\u0430\u0441\u0441\u044b\u043b\u043a\u0430"),
         )
         router.callback_query.register(
             self._cb_send_survey,

--- a/plugins_admin/plugin_list_plugin.py
+++ b/plugins_admin/plugin_list_plugin.py
@@ -1,7 +1,13 @@
 """Plugin that lists loaded plugins."""
 
 from aiogram import Router, types
-from aiogram.filters import Command
+try:
+    from aiogram.filters import Command, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 
 from plugin_manager import PluginManager
 from utils import remove_plugin_handlers
@@ -33,7 +39,7 @@ class PluginListPlugin:
     async def register_handlers(self, router: Router):
         router.message.register(self.cmd_plugins, Command("plugins"))
         router.message.register(
-            self.cmd_plugins, lambda m: m.text == "\ud83d\udd0c \u041f\u043b\u0430\u0433\u0438\u043d\u044b"
+            self.cmd_plugins, Text("\ud83d\udd0c \u041f\u043b\u0430\u0433\u0438\u043d\u044b")
         )
         router.callback_query.register(self.cb_plugins, lambda c: c.data == "plugins")
 

--- a/plugins_admin/roles_plugin.py
+++ b/plugins_admin/roles_plugin.py
@@ -10,7 +10,13 @@ from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.filters import Command, StateFilter
+try:
+    from aiogram.filters import Command, StateFilter, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command, StateFilter
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 from utils import remove_plugin_handlers
 
 __plugin_meta__ = {
@@ -85,7 +91,7 @@ class RolesPlugin:
 
         router.message.register(self.cmd_roles, Command("roles"))
         router.message.register(
-            self.cmd_roles, lambda msg: msg.text == "\ud83d\udd11 \u0420\u043e\u043b\u0438"
+            self.cmd_roles, Text("\ud83d\udd11 \u0420\u043e\u043b\u0438")
         )
 
         router.callback_query.register(

--- a/plugins_surveys/export_plugin.py
+++ b/plugins_surveys/export_plugin.py
@@ -24,7 +24,13 @@ __plugin_meta__ = {
 
 from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
-from aiogram.filters import Command
+try:
+    from aiogram.filters import Command, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 from utils import remove_plugin_handlers
 
 # Импорт хранилища
@@ -48,7 +54,7 @@ class ExportPlugin:
     async def register_handlers(self, router: Router):
         router.message.register(self.cmd_export, Command("export_data"))
         router.message.register(
-            self.cmd_export, lambda msg: msg.text == "\ud83d\udce6 \u042d\u043a\u0441\u043f\u043e\u0440\u0442"
+            self.cmd_export, Text("\ud83d\udce6 \u042d\u043a\u0441\u043f\u043e\u0440\u0442")
         )
         router.callback_query.register(
             self._cb_export, lambda c: c.data == "export_data"

--- a/plugins_surveys/scheduler_plugin.py
+++ b/plugins_surveys/scheduler_plugin.py
@@ -15,7 +15,13 @@ from aiogram import Router, types, Bot
 from aiogram.fsm.context import FSMContext  # <-- Вместо dispatcher.FSMContext
 from aiogram.fsm.state import StatesGroup, State  # <-- Вместо dispatcher.filters.state
 from aiogram.utils.keyboard import InlineKeyboardBuilder
-from aiogram.filters import Command
+try:
+    from aiogram.filters import Command, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 from utils import remove_plugin_handlers, try_pin_message
 
 __plugin_meta__ = {
@@ -65,7 +71,8 @@ class SchedulerPlugin:
 
         router.message.register(self.cmd_schedule, Command("schedule"))
         router.message.register(
-            self.cmd_schedule, lambda msg: msg.text == "\u23f0 \u041f\u043b\u0430\u043d\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u0435"
+            self.cmd_schedule,
+            Text("\u23f0 \u041f\u043b\u0430\u043d\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u0435"),
         )
 
         # Вместо dp.register_message_handler(...), используем dp.message.register(...)

--- a/plugins_surveys/survey_plugin.py
+++ b/plugins_surveys/survey_plugin.py
@@ -8,7 +8,13 @@ from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.filters import StateFilter
+try:
+    from aiogram.filters import StateFilter, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import StateFilter
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 import uuid
 from datetime import datetime, timedelta, time
 import asyncio
@@ -76,7 +82,7 @@ class SurveyPlugin:
         # Обработчики создания опроса
         # вход через меню администратора
         router.message.register(
-            self.cmd_create_survey, lambda msg: msg.text == "Создать опрос"
+            self.cmd_create_survey, Text("Создать опрос")
         )
         router.message.register(self.process_title, StateFilter(SurveyStates.TITLE))
         router.message.register(
@@ -139,7 +145,7 @@ class SurveyPlugin:
         # Обработчики управления опросами
         # просмотр доступен через меню
         router.message.register(
-            self.cmd_view_surveys, lambda msg: msg.text == "Мои опросы"
+            self.cmd_view_surveys, Text("Мои опросы")
         )
         router.callback_query.register(
             self.process_survey_action, lambda c: c.data.startswith("survey_")

--- a/plugins_surveys/test_mode_plugin.py
+++ b/plugins_surveys/test_mode_plugin.py
@@ -3,7 +3,13 @@ from aiogram import Router, types
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.filters import Command
+try:
+    from aiogram.filters import Command, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 import logging
 import copy
 from utils import remove_plugin_handlers
@@ -38,7 +44,7 @@ class SurveyTestModePlugin:
         router.message.register(self.cmd_test_mode, Command("test_mode"))
         router.message.register(
             self.cmd_test_mode,
-            lambda msg: msg.text == "\ud83e\uddea \u0422\u0435\u0441\u0442\u043e\u0432\u044b\u0439 \u0440\u0435\u0436\u0438\u043c",
+            Text("\ud83e\uddea \u0422\u0435\u0441\u0442\u043e\u0432\u044b\u0439 \u0440\u0435\u0436\u0438\u043c"),
         )
         router.callback_query.register(
             self.handle_survey_selection, lambda c: c.data.startswith("test_survey_")

--- a/plugins_surveys/view_surveys_plugin.py
+++ b/plugins_surveys/view_surveys_plugin.py
@@ -8,7 +8,13 @@
 from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.filters import Command, StateFilter
+try:
+    from aiogram.filters import Command, StateFilter, Text
+except Exception:  # pragma: no cover - fallback for test stubs
+    from aiogram.filters import Command, StateFilter
+
+    def Text(text):
+        return lambda m: getattr(m, "text", None) == text
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 import logging
 from utils import remove_plugin_handlers
@@ -104,8 +110,7 @@ class ViewSurveysPlugin:
         """Регистрирует все обработчики плагина"""
         router.message.register(self.cmd_view_surveys, Command("view_surveys"))
         router.message.register(
-            self.cmd_view_surveys,
-            lambda msg: msg.text == "\ud83d\udcca \u041c\u043e\u0438 \u043e\u043f\u0440\u043e\u0441\u044b",
+            self.cmd_view_surveys, Text("\ud83d\udcca \u041c\u043e\u0438 \u043e\u043f\u0440\u043e\u0441\u044b")
         )
         router.callback_query.register(
             self._cb_view_surveys, lambda c: c.data == "view_surveys"


### PR DESCRIPTION
## Summary
- ensure all menu button handlers work even when `aiogram.filters.Text` isn't available
- fallback to a simple lambda checking `message.text` for older test stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839ad34dfc832a8118afeb12499f7f