### PR TITLE
Fix Excel export with no data

### DIFF
--- a/plugins_surveys/export_plugin.py
+++ b/plugins_surveys/export_plugin.py
@@ -204,6 +204,11 @@ class ExportPlugin:
             )
             grouped[key].append({"question": question_text, "answer": answer})
 
+        if not grouped:
+            await callback_query.message.edit_text("Нет данных для экспорта.")
+            await callback_query.answer()
+            return
+
         filename = None
         for key, resp_list in grouped.items():
             user_id, username, group_id, group_name, timestamp = key

--- a/tests/test_export_excel_plugin.py
+++ b/tests/test_export_excel_plugin.py
@@ -79,3 +79,27 @@ def test_export_excel_file(tmp_path, monkeypatch):
         "Question",
         "Answer",
     ]
+
+
+def test_export_excel_no_data(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "pandas", real_pandas)
+    monkeypatch.setitem(sys.modules, "openpyxl", real_openpyxl)
+    importlib.reload(data_manager)
+    monkeypatch.setattr(data_manager, "DATA_FOLDER", str(tmp_path))
+
+    mod = importlib.reload(importlib.import_module("plugins_surveys.export_plugin"))
+    plugin = mod.load_plugin()
+
+    survey = {
+        "id": "s1",
+        "title": "Survey 1",
+        "questions": [{"id": "q1", "text": "Q1", "type": "text_answer"}],
+        "responses": [],
+    }
+
+    cb = DummyCallback()
+    asyncio.run(plugin.export_excel(cb, survey))
+
+    # No document should be sent and no file created
+    assert cb.message.docs == []
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- handle surveys with no responses in `export_excel`
- regression test to ensure empty response surveys don't raise errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891098eda0832ab3423c09649a0009