### PR TITLE
Update env path warning

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,8 @@ from plugin_manager import PluginManager, MissingRequiredPluginsError
 from routers.menu_router import router as menu_router
 from handlers.survey_handlers import register_survey_handlers
 
-load_dotenv(Path(__file__).resolve().with_name(".env"))
+ENV_PATH = Path(__file__).resolve().with_name(".env")
+load_dotenv(ENV_PATH)
 
 try:
     from aiogram.client.bot import Bot, DefaultBotProperties
@@ -40,7 +41,7 @@ if parse_version(aiogram_version).major != 3:
         "Kadron requires aiogram 3.x. Install dependencies via pip install -r requirements.txt."
     )
 
-if not os.path.exists(".env"):
+if not ENV_PATH.exists():
     logging.warning("Файл .env не найден; переменные окружения не загружены")
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")


### PR DESCRIPTION
## Summary
- use `ENV_PATH` for consistency when loading `.env`
- warn if that specific path doesn't exist

## Testing
- `black . --line-length 88`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b1d5f7d5c832a9f3907b2f8296796